### PR TITLE
Anime les cartes sur le catalogue et la page service

### DIFF
--- a/_layouts/service.html
+++ b/_layouts/service.html
@@ -95,9 +95,6 @@ script: /scripts/service.js
                 <div class="contenu">
                     <h3>{{ressource.titre}}</h3>
                     <span>{{ressource.description}}</span>
-                    <a href="{{ressource.url}}">En savoir plus
-                        <img src="/assets/images/icone-fleche-droite.svg">
-                    </a>
                     <div class="labels">
                         {% for source in ressource.sources %}
                         <span>{{source}}</span>

--- a/_layouts/service.html
+++ b/_layouts/service.html
@@ -99,8 +99,15 @@ script: /scripts/service.js
                         {% for source in ressource.sources %}
                         <span>{{source}}</span>
                         {% endfor %}
-                        <a class="lien-externe" href="{{ressource.lien}}" target="_blank"><img
-                                src="/assets/images/icone-lien-externe.svg"> </a>
+                        {% if ressource.avecFicheDetaillee %}
+                            <img src="/assets/images/icone-fleche-droite.svg"
+                                alt="Voir le détail"
+                                title="Voir le détail">
+                        {% else %}
+                            <img src="/assets/images/icone-lien-externe.svg"
+                                alt="Ouvrir dans un nouvel onglet"
+                                title="Ouvrir dans un nouvel onglet">
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/_layouts/service.html
+++ b/_layouts/service.html
@@ -87,7 +87,11 @@ script: /scripts/service.js
             {% for idRessource in page.ressources %}
             {% assign ressource = site.ressources | where: "id", idRessource | first %}
 
-            <div class="carte ressource">
+            {% if ressource.avecFicheDetaillee %}
+                <a class="carte ressource" href="{{ressource.url}}">
+            {% else %}
+                <a class="carte ressource" href="{{ressource.lien}}">
+            {% endif %}
                 <figure>
                     <img src="/assets/images/illustrations-services/{{ressource.illustration}}">
                     <figcaption>{{ressource.format}}</figcaption>
@@ -110,7 +114,7 @@ script: /scripts/service.js
                         {% endif %}
                     </div>
                 </div>
-            </div>
+            </a>
             {% endfor %}
         </section>
 

--- a/_ressources/demain-specialiste-cyber.md
+++ b/_ressources/demain-specialiste-cyber.md
@@ -2,6 +2,7 @@
 layout: service
 typologie: ressource
 nom: Demain&ZeroWidthSpace;Spécialiste&ZeroWidthSpace;Cyber
+avecFicheDetaillee: true
 titreHtml: 
 description: S’informer sur la cybersécurité et ses métiers.
 illustration: demainspecialistecyber/demainspecialistecyber.png

--- a/_ressources/livret-cyber-enjeux.md
+++ b/_ressources/livret-cyber-enjeux.md
@@ -2,6 +2,7 @@
 layout: service
 typologie: ressource
 nom: Livret et fiches découvrir la cybersécurité
+avecFicheDetaillee: true
 titreHtml: Livret et fiches découvrir la cybersécurité
 description: Découvrir le domaine de la cybersécurité et ses enjeux au travers de 13 fiches pédagogiques.
 besoins:

--- a/_services/mon-aide-cyber.md
+++ b/_services/mon-aide-cyber.md
@@ -2,6 +2,7 @@
 layout: service
 typologie: service
 nom: Mon&ZeroWidthSpace;Aide&ZeroWidthSpace;Cyber
+avecFicheDetaillee: true
 description: Lorem ipsum dolor sit amet consectitur lorem
 titreHtml: MonAideCyber
 illustration: mac/mac.png

--- a/_services/mon-service-securise.md
+++ b/_services/mon-service-securise.md
@@ -2,6 +2,7 @@
 layout: service
 typologie: service
 nom: Mon&ZeroWidthSpace;Service&ZeroWidthSpace;Sécurisé
+avecFicheDetaillee: true
 titreHtml: MonServiceSécurisé
 description: "MonServiceSécurisé aide les entités publiques à sécuriser et homologuer leurs services publics numériques&nbsp;: site web, applications mobiles, API."
 lien: https://monservicesecurise.cyber.gouv.fr/

--- a/assets/styles/catalogue.scss
+++ b/assets/styles/catalogue.scss
@@ -522,6 +522,7 @@
 .carte.ressource {
   display: flex;
   flex-direction: column;
+  width: auto;
 
   @include a-partir-de(md) {
     height: 406px;

--- a/assets/styles/catalogue.scss
+++ b/assets/styles/catalogue.scss
@@ -551,6 +551,7 @@
       line-height: 1.75rem;
       height: 84px;
       overflow: hidden;
+      margin-bottom: 8px;
     }
   }
 }

--- a/assets/styles/catalogue.scss
+++ b/assets/styles/catalogue.scss
@@ -530,10 +530,6 @@
 
   figure {
     height: 156px;
-
-    @include a-partir-de(md) {
-      height: 174px;
-    }
   }
 
   .contenu {

--- a/assets/styles/site.scss
+++ b/assets/styles/site.scss
@@ -121,8 +121,13 @@ header {
   text-decoration: none;
   color: var(--noir);
 
-  &:hover .contenu {
-    background: #f6f6f6;
+  &:hover {
+    figure img {
+      transform: translateY(0);
+    }
+    .contenu {
+      background: #f6f6f6;
+    }
   }
 
   figure {
@@ -140,6 +145,8 @@ header {
       height: 131px;
       width: 243px;
       box-shadow: 0 4px 12px 0 rgba(0, 0, 18, 0.32);
+      transform: translateY(8px);
+      transition: all 0.1s ease;
     }
 
     figcaption {

--- a/assets/styles/site.scss
+++ b/assets/styles/site.scss
@@ -118,6 +118,8 @@ header {
   display: flex;
   flex-direction: column;
   width: 286px;
+  text-decoration: none;
+  color: var(--noir);
 
   figure {
     height: 157px;

--- a/assets/styles/site.scss
+++ b/assets/styles/site.scss
@@ -280,6 +280,10 @@ footer {
     line-height: 1.5rem;
     font-weight: normal;
   }
+
+  img {
+    margin-left: auto;
+  }
 }
 
 .sommaire-replie {

--- a/assets/styles/site.scss
+++ b/assets/styles/site.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import 'responsive';
+@import "responsive";
 
 :root {
   --noir: #0d0c21;
@@ -20,7 +20,6 @@ body {
   color: var(--noir);
   margin: 0;
 }
-
 
 header {
   nav {
@@ -88,7 +87,7 @@ header {
 }
 
 .bouton {
-  font-family: 'Marianne';
+  font-family: "Marianne";
   display: flex;
   justify-content: center;
   border-radius: 8px;
@@ -112,7 +111,8 @@ header {
   color: white;
 }
 
-.carte.ressource, .carte.service {
+.carte.ressource,
+.carte.service {
   border: 1px solid #ddd;
   border-radius: 8px;
   display: flex;
@@ -151,7 +151,7 @@ header {
       border-radius: 8px;
 
       &:before {
-        content: '';
+        content: "";
         background-image: url("/assets/images/icone-ressource.svg");
         width: 12px;
         height: 12px;
@@ -173,7 +173,7 @@ header {
     h3 {
       margin: 0;
       padding: 0;
-      font-size: .875rem;
+      font-size: 0.875rem;
       line-height: 1.5rem;
       font-weight: 400;
     }
@@ -260,7 +260,7 @@ footer {
   a {
     text-decoration: none;
     color: var(--noir);
-    font-size: .75rem;
+    font-size: 0.75rem;
     line-height: 1.5rem;
   }
 }
@@ -304,13 +304,13 @@ footer {
   }
 
   details {
-    &[open] summary .entete-filtres .chevron  {
+    &[open] summary .entete-filtres .chevron {
       transform: rotate(180deg);
     }
 
     summary {
       &::marker {
-        content: '';
+        content: "";
       }
 
       &::-webkit-details-marker {
@@ -333,5 +333,4 @@ footer {
       flex-grow: 1;
     }
   }
-
 }

--- a/assets/styles/site.scss
+++ b/assets/styles/site.scss
@@ -121,6 +121,10 @@ header {
   text-decoration: none;
   color: var(--noir);
 
+  &:hover .contenu {
+    background: #f6f6f6;
+  }
+
   figure {
     height: 157px;
     display: flex;

--- a/assets/styles/site.scss
+++ b/assets/styles/site.scss
@@ -117,6 +117,7 @@ header {
   border-radius: 8px;
   display: flex;
   flex-direction: column;
+  width: 286px;
 
   figure {
     height: 157px;

--- a/assets/styles/site.scss
+++ b/assets/styles/site.scss
@@ -270,6 +270,7 @@ footer {
   gap: 8px;
   align-items: center;
   flex-wrap: wrap;
+  margin-top: auto;
 
   span {
     border-radius: 12px;

--- a/catalogue.html
+++ b/catalogue.html
@@ -31,7 +31,7 @@ permalink: /catalogue/
           "typologie": "{{ service.typologie }}",
           "illustration": "{{ service.illustration }}",
           "description": "{{ service.description }}",
-          "lienInterne": "{{ service.url }}",
+          {% if service.avecFicheDetaillee %} "lienInterne": "{{ service.url }}", {% endif %}
           "lienExterne": "{{ service.lien }}",
           "sources": {{ service.sources | jsonify }},
           "besoins": {{ service.besoins | jsonify }},
@@ -48,7 +48,7 @@ permalink: /catalogue/
               "typologie": "{{ ressource.typologie }}",
               "illustration": "{{ ressource.illustration }}",
               "description": "{{ ressource.description }}",
-              "lienInterne": "{{ ressource.url }}",
+              {% if ressource.avecFicheDetaillee %} "lienInterne": "{{ ressource.url }}", {% endif %}
               "lienExterne": "{{ ressource.lien }}",
               "sources": {{ ressource.sources | jsonify }},
               "besoins": {{ ressource.besoins | jsonify }},

--- a/lib-catalogue/src/CarteItem.svelte
+++ b/lib-catalogue/src/CarteItem.svelte
@@ -25,10 +25,6 @@
   <div class="contenu">
     <h3>{@html itemCyber.nom}</h3>
     <span class="description">{@html tronque(itemCyber.description)}</span>
-    <a href={itemCyber.lienInterne}>
-      En savoir plus
-      <img src="/assets/images/icone-fleche-droite.svg" alt="En savoir plus" />
-    </a>
     <div class="labels">
       {#each itemCyber.sources as source}<span>{source}</span>{/each}
       <a

--- a/lib-catalogue/src/CarteItem.svelte
+++ b/lib-catalogue/src/CarteItem.svelte
@@ -27,16 +27,19 @@
     <span class="description">{@html tronque(itemCyber.description)}</span>
     <div class="labels">
       {#each itemCyber.sources as source}<span>{source}</span>{/each}
-      <a
-        class="lien-externe"
-        href={itemCyber.lienExterne}
-        target="_blank"
-        aria-label="Ouvrir le lien"
-        ><img
-          src="/assets/images/icone-lien-externe.svg"
-          alt="Ouvrir dans un nouvel onglet"
-        />
-      </a>
+      <img
+        src={`/assets/images/${
+          itemCyber.lienInterne
+            ? "icone-fleche-droite.svg"
+            : "icone-lien-externe.svg"
+        }`}
+        alt={itemCyber.lienInterne
+          ? "Voir le détail"
+          : "Ouvrir dans un nouvel onglet"}
+        title={itemCyber.lienInterne
+          ? "Voir le détail"
+          : "Ouvrir dans un nouvel onglet"}
+      />
     </div>
   </div>
 </div>

--- a/lib-catalogue/src/CarteItem.svelte
+++ b/lib-catalogue/src/CarteItem.svelte
@@ -14,7 +14,10 @@
   };
 </script>
 
-<div class="carte {itemCyber.typologie}">
+<a
+  class="carte {itemCyber.typologie}"
+  href={itemCyber.lienInterne ?? itemCyber.lienExterne}
+>
   <figure>
     <img
       src="/assets/images/illustrations-services/{itemCyber.illustration}"
@@ -42,4 +45,4 @@
       />
     </div>
   </div>
-</div>
+</a>


### PR DESCRIPTION
Cette PR change le look des cartes, et les anime au survol.

La mention verte disparaît, et le violet est soit un picto de lien interne soit un picto de lien interne 👇 
![image](https://github.com/user-attachments/assets/eafbfa62-deb5-46f5-a458-3eb31b7b7791)

Résultat 👇 
![image](https://github.com/user-attachments/assets/b1d8b4a1-0cf4-41fc-8d8a-cdd5315763b6)


Au survol, les illustrations se soulèvent de `8px` et on a une couleur de fond 👇 

![image](https://github.com/user-attachments/assets/11e5b57f-cf20-47f0-937c-ad541a02e497)
