### PR TITLE
Corrige des défauts visuels

### DIFF
--- a/assets/styles/catalogue.scss
+++ b/assets/styles/catalogue.scss
@@ -180,6 +180,7 @@
       display: flex;
       gap: 8px;
       align-items: center;
+      cursor: pointer;
 
       .libelle {
         display: flex;
@@ -207,6 +208,7 @@
         width: 24px;
         height: 24px;
         margin: 0;
+        cursor: pointer;
 
         &:checked {
           background-color: #fed980;

--- a/assets/styles/catalogue.scss
+++ b/assets/styles/catalogue.scss
@@ -34,7 +34,7 @@
   h1 {
     font-size: 2.5rem;
     line-height: 2.875rem;
-    margin: 0;
+    margin: 0 0 16px;
 
     @include a-partir-de(md) {
       font-size: 3.5rem;

--- a/lib-catalogue/src/FiltreTypologieEtFormat.svelte
+++ b/lib-catalogue/src/FiltreTypologieEtFormat.svelte
@@ -66,7 +66,7 @@
         value={FormatRessource.PDF}
         bind:group={$rechercheParFormat}
       />
-      <span class="libelle">Pdf</span>
+      <span class="libelle">PDF</span>
       <span class="compte"
         >{$nombreResultats.parFormatDeRessource[FormatRessource.PDF]}</span
       >


### PR DESCRIPTION
...suite à la recette :
 - mot « PDF » dans la mauvaise casse
 - pointeur sur les cases à cocher
 - espace entre le titre et le sous-titre