### PR TITLE
Corrige les filtres suite à l’ajout de nouveaux items

### DIFF
--- a/lib-catalogue/src/stores/rechercheParSource.store.ts
+++ b/lib-catalogue/src/stores/rechercheParSource.store.ts
@@ -27,6 +27,7 @@ export const rechercheParSource = {
   ok: (item: ItemCyber) => {
     const sources = get(rechercheParSource);
     if (sources.length === 0) return true;
+    if (!item.sources) return false;
     if (item.sources.includes(Source.ANSSI)) {
       const secondaire = item.sources.find((s) => s !== Source.ANSSI);
       if (secondaire) {

--- a/lib-catalogue/test/stores/rechercheParSource.store.spec.ts
+++ b/lib-catalogue/test/stores/rechercheParSource.store.spec.ts
@@ -37,4 +37,15 @@ describe("La recherche par source", () => {
 
     expect(get(rechercheParSource)).toEqual([]);
   });
+
+  it("ne retourne pas un item sans source", () => {
+    rechercheParSource.set([Source.PARTENAIRES]);
+    let sansSource ={... guidesTechniques()};
+    delete sansSource.sources
+
+    const resultat = rechercheParSource.ok(sansSource);
+
+    expect(resultat).toBe(false);
+  });
+
 });


### PR DESCRIPTION
- le filtre source reste robuste lorsque certains items n’ont pas de source