### PR TITLE
Corrige l’adresse de l’image dans les balises meta

### DIFF
--- a/_layouts/test-maturite.html
+++ b/_layouts/test-maturite.html
@@ -5,7 +5,7 @@ balisesMeta:
   - propriete: "og:title"
     contenu: Test de maturité Cyber
   - propriete: "og:image"
-    contenu: SITE_URL/images/test-maturite/test-maturite.png
+    contenu: SITE_URL/assets/images/test-maturite/test-maturite.png
   - propriete: "og:description"
     contenu: Obtenez en 5 minutes une évaluation indicative de la maturité cyber de votre organisation.
   - propriete: "og:url"


### PR DESCRIPTION
Afin que le partage LinkedIn lise correctement l’image