### PR TITLE
Corrige le lancement de l’image docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN npx tsc
 FROM node:23-alpine
 EXPOSE 3000
 WORKDIR /usr/src/app
-COPY --from=build-le-back /usr/src/app/package.json /usr/src/app/
+COPY package.json /usr/src/app/
 COPY --from=build-le-back /usr/src/app/node_modules/ /usr/src/app/node_modules/
 COPY --from=build-le-site /srv/jekyll/_site/ /usr/src/app/front/_site/
 COPY --from=build-le-back /usr/src/app/dist-back/ /usr/src/app/dist-back/


### PR DESCRIPTION
...en copiant le fichier package.json qui se situe à la racine