### PR TITLE
Utilise les variables `--build-arg` passées dans le Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ RUN npm install && npm run build
 
 # Build du site
 WORKDIR /srv/jekyll
+ARG MATOMO_ID
+RUN touch .env
+RUN echo "MATOMO_ID=${MATOMO_ID}" >> .env
 RUN set -eux; bundler exec jekyll build
 
 ####

--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ $ npm run dev
 ## Le build et la PROD
 On utilise un unique `Dockerfile` pour le build via CI/CD et l'hébergement sur notre PaaS.  
 Le `Dockerfile` unique est la solution qui semble la plus simple.
+Certaines variables d'environnement sont nécessaires au moment de la construction du site statique (avec Jekyll).
+Pour ce faire, ces variables sont passées via les `--build-arg` par CleverCloud. On peut donc les utiliser dans notre Dockerfile.
+Exemple : 
+```Dockerfile
+ARG MA_VARIABLE
+RUN echo "MA_VARIABLE=${MA_VARIABLE}" >> .env
+```
+Ces variables sont passées à Jekyll via le plugin [jekyll-dotenv](https://www.rubydoc.info/gems/jekyll-dotenv/0.2.0)


### PR DESCRIPTION
... afin de construire correctement le site avec Jekyll, et dans notre cas, en activant ou non Matomo.