### PR TITLE
Ajoute des headers de sécurité

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,6 @@
+# Serveur
 URL_BASE_MSC= # URL de base du site web, ex. http://messervices.cyber.gouv.fr
+CACHE_CONTROL_FICHIERS_STATIQUES = # politique de `cache-control` sur les fichiers statiques, mettre à `no-store` ou `public, max-age=0` pour le dev. local
 
 # OIDC
 OIDC_URL_BASE = # Adresse de base du serveur OIDC

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -13,6 +13,7 @@
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
         "express-validator": "^7.2.1",
+        "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
         "openid-client": "^5.7.0"
       },
@@ -1820,6 +1821,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.0.0.tgz",
+      "integrity": "sha512-VyusHLEIIO5mjQPUI1wpOAEu+wl6Q0998jzTxqUYGE45xCIcAxy3MsbEK/yyJUJ3ADeMoB6MornPH6GMWAf+Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hexoid": {

--- a/back/package.json
+++ b/back/package.json
@@ -29,6 +29,7 @@
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.0",
     "express-validator": "^7.2.1",
+    "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
     "openid-client": "^5.7.0"
   }

--- a/back/src/api/middleware.ts
+++ b/back/src/api/middleware.ts
@@ -9,6 +9,7 @@ type FonctionMiddleware = (
 
 export type Middleware = {
   aseptise: (...nomsParametres: string[]) => FonctionMiddleware;
+  interdisLaMiseEnCache: FonctionMiddleware;
 };
 
 export const fabriqueMiddleware = (): Middleware => {
@@ -22,7 +23,18 @@ export const fabriqueMiddleware = (): Middleware => {
       suite();
     };
 
+  const interdisLaMiseEnCache = async (_requete: Request, reponse: Response, suite: NextFunction) => {
+    reponse.set({
+      'cache-control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      pragma: 'no-cache',
+      expires: '0',
+      'surrogate-control': 'no-store',
+    });
+    suite();
+  };
+
   return {
     aseptise,
+    interdisLaMiseEnCache
   };
 };

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -1,5 +1,6 @@
 import cookieParser from 'cookie-parser';
 import cookieSession from 'cookie-session';
+import helmet from 'helmet';
 import express, { Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
 import { ConfigurationServeur } from './configurationServeur';
@@ -14,6 +15,8 @@ import { ressourceProfil } from './ressourceProfil';
 
 const creeServeur = (configurationServeur: ConfigurationServeur) => {
   const app = express();
+
+  app.use(helmet());
 
   const centParMinute = rateLimit({
     windowMs: 60 * 1000,

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -67,7 +67,10 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
   ['assets', 'scripts', 'lib-svelte', 'favicon.ico'].forEach((ressource) => {
     app.use(
       `/${ressource}`,
-      express.static(fournisseurChemin.ressourceDeBase(ressource))
+      express.static(fournisseurChemin.ressourceDeBase(ressource), {
+        setHeaders: (reponse: Response) =>
+          reponse.setHeader('cache-control', process.env.CACHE_CONTROL_FICHIERS_STATIQUES || 'no-store'),
+      })
     );
   });
 

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -17,6 +17,7 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
   const app = express();
 
   app.use(helmet());
+  app.use(configurationServeur.middleware.interdisLaMiseEnCache);
 
   const centParMinute = rateLimit({
     windowMs: 60 * 1000,

--- a/back/tests/api/middleware.spec.ts
+++ b/back/tests/api/middleware.spec.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import { fabriqueMiddleware, Middleware } from '../../src/api/middleware';
 import assert from 'assert';
 import { createRequest, createResponse } from 'node-mocks-http';
+import { OutgoingHttpHeaders } from 'node:http';
 
 describe('Le middleware', () => {
   let requete: Request & { service?: string };
@@ -64,6 +65,22 @@ describe('Le middleware', () => {
         paramRenseigne,
         '&lt;script&gt;alert(&quot;hacked!&quot;);&lt;&#x2F;script&gt;'
       );
+    });
+  });
+
+  describe("sur demande d'interdiction de mise en cache", () => {
+    it('interdit la mise en cache', async () => {
+      let headers: OutgoingHttpHeaders = {};
+      const suite = () => {
+        headers = reponse.getHeaders();
+      };
+      await middleware.interdisLaMiseEnCache(requete, reponse, suite);
+
+
+      assert.equal(headers['cache-control'], 'no-store, no-cache, must-revalidate, proxy-revalidate');
+      assert.equal(headers.pragma, 'no-cache');
+      assert.equal(headers.expires, '0');
+      assert.equal(headers['surrogate-control'], 'no-store');
     });
   });
 });


### PR DESCRIPTION
On utilise [Helmet](https://helmetjs.github.io/) pour obtenir une configuration de base de sécurité.
On rajoute :
- Une politique de `no-cache` au global
- Une politique de "Cache" sur les fichiers statiques afin de garder de la fluidité sur les assets du site.

> [!CAUTION]
> Il faut valoriser la variable d'env. `CACHE_CONTROL_FICHIERS_STATIQUES` au moment de la mise en production 