### PR TITLE
Corrige le script pour lancer la migration knex dans le déploiement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "installe-tout": "npx concurrently -n \"SERVEUR,SVELTE,JEKYLL\" \"npm install --prefix back\" \"npm install --prefix front/lib-svelte\" \"npm install\" ",
     "migre-bdd": "node --env-file=.env back/node_modules/knex/bin/cli.js migrate:latest --knexfile back/knexfile.ts",
-    "migre-bdd-clever": "node back/node_modules/knex/bin/cli.js migrate:latest --knexfile back/knexfile.ts",
+    "migre-bdd-clever": "node node_modules/knex/bin/cli.js migrate:latest --knexfile knexfile.ts",
     "dev": "npx concurrently -n \"SERVEUR,SVELTE,JEKYLL,BDD,MIGRE\" \"node --watch --import tsx --env-file .env ./back/src/serveur.ts\" \"npm run watch --prefix front/lib-svelte\" \"sleep 3 && jekyll build -s ./front -d ./front/_site -w\" \"docker compose up msc-db\" \"sleep 3 && npm run migre-bdd\"",
     "start": "npm run migre-bdd-clever && node ./dist-back/serveur.js"
   },


### PR DESCRIPTION
... On corrige le chemin relatif vers les fichiers pour l'ORM knex, les dépendances et les fichiers de configurations sont copiés à la racine dans le Dockerfile