### PR TITLE
Appliquer le rate-limit dans le contexte d'un reverse proxy 2

### DIFF
--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -24,7 +24,7 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
     limit: 100,
     skip: (req) => req.url.startsWith('/assets'),
   });
-  app.set('trust proxy', 1);
+  app.set('trust proxy', 2);
   app.use(centParMinute);
 
   app.use(

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -27,6 +27,13 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
   app.set('trust proxy', 2);
   app.use(centParMinute);
 
+  // A supprimer
+  // On logue les en-têtes HTTP pour vérifier la mise au point des paramètres de proxy
+  app.use((req, res, next) => {
+    console.log('Headers:', req.headers);
+    next();
+  });
+
   app.use(
     cookieSession({
       name: 'session',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,11 @@
-version: '3'
-
-x-app: &configuration-base
-  build:
-    context: .
-
 services:
   app:
     build:
       context: .
     env_file:
       - .env
+    ports:
+      - '3000:3000'
 
   db:
     image: postgres:14


### PR DESCRIPTION
On considère que le service est exposé derrière deux reverse proxies. On doit mettre trust proxy à 2 dans ce cas.

Cf. https://expressjs.com/en/guide/behind-proxies.html

Aussi, on log, provisoirement, les en-tête HTTP reçu pour valider sur chaque environnement les en-têtes positionnés par les proxies.