### PR TITLE
Rate limit proxy paramétrable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,7 @@
 # Serveur
 URL_BASE_MSC= # URL de base du site web, ex. http://messervices.cyber.gouv.fr
 CACHE_CONTROL_FICHIERS_STATIQUES = # politique de `cache-control` sur les fichiers statiques, mettre à `no-store` ou `public, max-age=0` pour le dev. local
+# SERVEUR_TRUST_PROXY = # optionnel nombre de proxies en amont du service ou configuration plus fine de trust proxy, Cf.  https://expressjs.com/en/guide/behind-proxies.html
 
 # OIDC
 OIDC_URL_BASE= # Adresse de base du serveur OIDC

--- a/back/src/api/configurationServeur.ts
+++ b/back/src/api/configurationServeur.ts
@@ -10,4 +10,5 @@ export type ConfigurationServeur = {
   adaptateurOIDC: AdaptateurOIDC;
   adaptateurJWT: AdaptateurJWT;
   entrepotUtilisateur: EntrepotUtilisateur;
+  trustProxy: String;
 };

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -27,13 +27,6 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
   app.set('trust proxy', 2);
   app.use(centParMinute);
 
-  // A supprimer
-  // On logue les en-têtes HTTP pour vérifier la mise au point des paramètres de proxy
-  app.use((req, res, next) => {
-    console.log('Headers:', req.headers);
-    next();
-  });
-
   app.use(
     cookieSession({
       name: 'session',

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -24,7 +24,7 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
     limit: 100,
     skip: (req) => req.url.startsWith('/assets'),
   });
-  app.set('trust proxy', 2);
+  app.set('trust proxy', configurationServeur.trustProxy);
   app.use(centParMinute);
 
   app.use(

--- a/back/src/infra/adaptateurEnvironnement.ts
+++ b/back/src/infra/adaptateurEnvironnement.ts
@@ -8,6 +8,9 @@ const adaptateurEnvironnement = {
     clientId: () => process.env.OIDC_CLIENT_ID || '',
     clientSecret: () => process.env.OIDC_CLIENT_SECRET || '',
   }),
+  serveur: () => ({
+    trustProxy: () => process.env.SERVEUR_TRUST_PROXY || '0',
+  }),
 };
 
 export { adaptateurEnvironnement };

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -4,6 +4,7 @@ import { fabriqueMiddleware } from './api/middleware';
 import { adaptateurOIDC } from './api/oidc/adaptateurOIDC';
 import { adaptateurJWT } from './api/adaptateurJWT';
 import { EntrepotUtilisateurPostgres } from './infra/entrepotUtilisateurPostgres';
+import { adaptateurEnvironnement } from './infra/adaptateurEnvironnement';
 
 creeServeur({
   fournisseurChemin,
@@ -11,6 +12,7 @@ creeServeur({
   adaptateurOIDC,
   adaptateurJWT,
   entrepotUtilisateur: new EntrepotUtilisateurPostgres(),
+  trustProxy: adaptateurEnvironnement.serveur().trustProxy(),
 }).listen(3000, () => {
   console.log('Le serveur écoute sur le port 3000');
 });


### PR DESCRIPTION
`trust proxy` est rendu paramétrable pour s'adapter à l'environnement.

Cf. https://expressjs.com/en/guide/behind-proxies.html

Aussi, on supprime le log des en-tête HTTP reçus qu'on avait mis en place provisoirement.