### PR TITLE
Simplifier la gestion du nombre maximum de requêtes par minute

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,9 @@
 # Serveur
 URL_BASE_MSC= # URL de base du site web, ex. http://messervices.cyber.gouv.fr
 CACHE_CONTROL_FICHIERS_STATIQUES = # politique de `cache-control` sur les fichiers statiques, mettre à `no-store` ou `public, max-age=0` pour le dev. local
-# SERVEUR_TRUST_PROXY = # optionnel nombre de proxies en amont du service ou configuration plus fine de trust proxy, Cf.  https://expressjs.com/en/guide/behind-proxies.html
+# SERVEUR_TRUST_PROXY = # optionnel (0 par défaut) nombre de proxies en amont du service ou configuration plus fine de trust proxy, Cf.  https://expressjs.com/en/guide/behind-proxies.html
+# SERVEUR_MAX_REQUETES_PAR_MINUTE = # optionnel (600 par défaut) nombre maximum de requêtes par minute par IP
+
 
 # OIDC
 OIDC_URL_BASE= # Adresse de base du serveur OIDC

--- a/back/src/api/configurationServeur.ts
+++ b/back/src/api/configurationServeur.ts
@@ -11,4 +11,5 @@ export type ConfigurationServeur = {
   adaptateurJWT: AdaptateurJWT;
   entrepotUtilisateur: EntrepotUtilisateur;
   trustProxy: String;
+  maxRequetesParMinutes: number;
 };

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -21,8 +21,7 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
 
   const centParMinute = rateLimit({
     windowMs: 60 * 1000,
-    limit: 100,
-    skip: (req) => req.url.startsWith('/assets'),
+    limit: configurationServeur.maxRequetesParMinutes,
   });
   app.set('trust proxy', configurationServeur.trustProxy);
   app.use(centParMinute);

--- a/back/src/infra/adaptateurEnvironnement.ts
+++ b/back/src/infra/adaptateurEnvironnement.ts
@@ -10,6 +10,15 @@ const adaptateurEnvironnement = {
   }),
   serveur: () => ({
     trustProxy: () => process.env.SERVEUR_TRUST_PROXY || '0',
+    maxRequetesParMinute: () => {
+      const maxEnChaine = process.env.SERVEUR_MAX_REQUETES_PAR_MINUTE || '600'
+      const maxEnNombre = Number(maxEnChaine);
+      if (isNaN(maxEnNombre)) {
+        throw new Error(`SERVEUR_MAX_REQUETES_PAR_MINUTE n'est pas un nombre : ${maxEnChaine}`);
+      } else {
+        return maxEnNombre
+      }
+    },
   }),
 };
 

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -13,6 +13,7 @@ creeServeur({
   adaptateurJWT,
   entrepotUtilisateur: new EntrepotUtilisateurPostgres(),
   trustProxy: adaptateurEnvironnement.serveur().trustProxy(),
+  maxRequetesParMinutes: adaptateurEnvironnement.serveur().maxRequetesParMinute(),
 }).listen(3000, () => {
   console.log('Le serveur écoute sur le port 3000');
 });


### PR DESCRIPTION
Pour éviter les difficultés de paramétrage, on applique la même limite sur le nombre de requêtes par minutes sur toutes les pages du service.

On fixe cette limite, par défaut, à 600 mais cela est paramétrable.