### PR TITLE
Corrige l’envoi du statut lors de la vérification JWT

### DIFF
--- a/back/src/api/middleware.ts
+++ b/back/src/api/middleware.ts
@@ -55,7 +55,7 @@ export const fabriqueMiddleware = ({ adaptateurJWT }: { adaptateurJWT: Adaptateu
     suite: NextFunction
   ) => {
     if(!requete.session?.token) {
-      reponse.status(401);
+      reponse.sendStatus(401);
       return;
     }
 
@@ -64,7 +64,7 @@ export const fabriqueMiddleware = ({ adaptateurJWT }: { adaptateurJWT: Adaptateu
       requete.emailUtilisateurCourant = email;
       suite();
     } catch(e) {
-      reponse.status(401);
+      reponse.sendStatus(401);
     }
   };
 

--- a/back/tests/api/middleware.spec.ts
+++ b/back/tests/api/middleware.spec.ts
@@ -123,7 +123,7 @@ describe('Le middleware', () => {
       requete.session = { token };
 
       let statutRecu;
-      reponse.status = (statut: number) => {
+      reponse.sendStatus = (statut: number) => {
         statutRecu = statut;
         return statutOriginal(statut);
       };
@@ -143,7 +143,7 @@ describe('Le middleware', () => {
       }
 
       let statutRecu;
-      reponse.status = (statut: number) => {
+      reponse.sendStatus = (statut: number) => {
         statutRecu = statut;
         return statutOriginal(statut);
       };


### PR DESCRIPTION
...il faut faire un `send` pour envoyer la réponse