### PR TITLE
Ajoute le filtrage IP

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,6 +3,7 @@ URL_BASE_MSC= # URL de base du site web, ex. http://messervices.cyber.gouv.fr
 CACHE_CONTROL_FICHIERS_STATIQUES= # politique de `cache-control` sur les fichiers statiques, mettre à `no-store` ou `public, max-age=0` pour le dev. local
 # SERVEUR_TRUST_PROXY = # optionnel (0 par défaut) nombre de proxies en amont du service ou configuration plus fine de trust proxy, Cf.  https://expressjs.com/en/guide/behind-proxies.html
 # SERVEUR_MAX_REQUETES_PAR_MINUTE = # optionnel (600 par défaut) nombre maximum de requêtes par minute par IP
+# SERVEUR_ADRESSES_IP_AUTORISEES = # Seules ces IP seront autorisées. Les autres ne seront pas servies. Séparées par des ',' s'il y en a plusieurs. Supprimer la variable d'env pour désactiver le filtrage.
 
 
 # OIDC

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 dist-back
 .vscode
 .env
+.idea

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -13,6 +13,7 @@
         "cookie-parser": "^1.4.7",
         "cookie-session": "^2.1.0",
         "express": "^4.21.2",
+        "express-ipfilter": "^1.3.2",
         "express-rate-limit": "^7.5.0",
         "express-validator": "^7.2.1",
         "helmet": "^8.0.0",
@@ -1719,6 +1720,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-ipfilter": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.2.tgz",
+      "integrity": "sha512-yMzCWGuVMnR8CFlsIC2spHWoQYp9vtyZXUgS/JdV5GOJgrz6zmKOEZsA4eF1XrxkOIVzaVk6yzTBk65pBhliNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip": "^2.0.1",
+        "lodash": "^4.17.11",
+        "proxy-addr": "^2.0.7",
+        "range_check": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
     "node_modules/express-rate-limit": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
@@ -2046,6 +2062,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "license": "MIT"
+    },
+    "node_modules/ip6": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/ip6/-/ip6-0.2.11.tgz",
+      "integrity": "sha512-OmTP7FyIp+ZoNvZ7Xr97bWrCgypa3BeuYuRFNTOPT8Y11cxMW1pW1VC70kHZP1onSHHMotADcjdg5QyECiIMUw==",
+      "license": "MIT",
+      "bin": {
+        "ip6": "ip6-cli.js"
       }
     },
     "node_modules/ipaddr.js": {
@@ -2769,6 +2800,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range_check": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/range_check/-/range_check-2.0.4.tgz",
+      "integrity": "sha512-aed0ocXXj+SIiNNN9b+mZWA3Ow2GXHtftOGk2xQwshK5GbEZAvUcPWNQBLTx/lPcdFRIUFlFCRtHTQNIFMqynQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip6": "^0.2.0",
+        "ipaddr.js": "^1.9.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/range-parser": {

--- a/back/package.json
+++ b/back/package.json
@@ -29,6 +29,7 @@
     "cookie-parser": "^1.4.7",
     "cookie-session": "^2.1.0",
     "express": "^4.21.2",
+    "express-ipfilter": "^1.3.2",
     "express-rate-limit": "^7.5.0",
     "express-validator": "^7.2.1",
     "helmet": "^8.0.0",

--- a/back/src/api/configurationServeur.ts
+++ b/back/src/api/configurationServeur.ts
@@ -18,8 +18,10 @@ export type ConfigurationServeur = {
   busEvenements: BusEvenements;
   adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise;
   entrepotUtilisateur: EntrepotUtilisateur;
-  trustProxy: String;
-  maxRequetesParMinutes: number;
+  reseau : {
+    trustProxy: string;
+    maxRequetesParMinutes: number;
+  };
   entrepotResultatTest: EntrepotResultatTest;
   adaptateurProfilAnssi: AdaptateurProfilAnssi;
 };

--- a/back/src/api/configurationServeur.ts
+++ b/back/src/api/configurationServeur.ts
@@ -21,6 +21,7 @@ export type ConfigurationServeur = {
   reseau : {
     trustProxy: string;
     maxRequetesParMinutes: number;
+    ipAutorisees: string[] | false;
   };
   entrepotResultatTest: EntrepotResultatTest;
   adaptateurProfilAnssi: AdaptateurProfilAnssi;

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -54,9 +54,9 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
 
   const limiteRequetesParMinute = rateLimit({
     windowMs: 60 * 1000,
-    limit: configurationServeur.maxRequetesParMinutes,
+    limit: configurationServeur.reseau.maxRequetesParMinutes,
   });
-  app.set('trust proxy', configurationServeur.trustProxy);
+  app.set('trust proxy', configurationServeur.reseau.trustProxy);
   app.use(limiteRequetesParMinute);
 
   app.use(

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -52,12 +52,12 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
   );
   app.use(configurationServeur.middleware.interdisLaMiseEnCache);
 
-  const centParMinute = rateLimit({
+  const limiteRequetesParMinute = rateLimit({
     windowMs: 60 * 1000,
     limit: configurationServeur.maxRequetesParMinutes,
   });
   app.set('trust proxy', configurationServeur.trustProxy);
-  app.use(centParMinute);
+  app.use(limiteRequetesParMinute);
 
   app.use(
     cookieSession({

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -3,6 +3,7 @@ import cookieSession from 'cookie-session';
 import express, { json, Request, Response } from 'express';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
+import { IpFilter } from 'express-ipfilter';
 import { ConfigurationServeur } from './configurationServeur';
 import { fournisseurChemin } from './fournisseurChemin';
 import { ressourceApresAuthentificationOIDC } from './oidc/ressourceApresAuthentificationOIDC';
@@ -58,6 +59,14 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
   });
   app.set('trust proxy', configurationServeur.reseau.trustProxy);
   app.use(limiteRequetesParMinute);
+
+  if (configurationServeur.reseau.ipAutorisees) {
+    console.log(`On accepte uniquement les Ips: ${configurationServeur.reseau.ipAutorisees}`)
+    app.use(IpFilter(configurationServeur.reseau.ipAutorisees, {
+      mode: 'allow',
+      log: false,
+    }));
+  }
 
   app.use(
     cookieSession({

--- a/back/src/infra/adaptateurEnvironnement.ts
+++ b/back/src/infra/adaptateurEnvironnement.ts
@@ -19,6 +19,7 @@ const adaptateurEnvironnement = {
         return maxEnNombre
       }
     },
+    ipAutorisees: () => process.env.SERVEUR_ADRESSES_IP_AUTORISEES?.split(',') ?? false,
   }),
   sentry: () => ({
     dsn: () => process.env.SENTRY_DSN,

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -39,6 +39,7 @@ creeServeur({
     maxRequetesParMinutes: adaptateurEnvironnement
       .serveur()
       .maxRequetesParMinute(),
+    ipAutorisees: adaptateurEnvironnement.serveur().ipAutorisees(),
   },
   adaptateurRechercheEntreprise,
   adaptateurProfilAnssi,

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -34,10 +34,12 @@ creeServeur({
     adaptateurProfilAnssi,
     adaptateurRechercheEntreprise
   ),
-  trustProxy: adaptateurEnvironnement.serveur().trustProxy(),
-  maxRequetesParMinutes: adaptateurEnvironnement
-    .serveur()
-    .maxRequetesParMinute(),
+  reseau : {
+    trustProxy: adaptateurEnvironnement.serveur().trustProxy(),
+    maxRequetesParMinutes: adaptateurEnvironnement
+      .serveur()
+      .maxRequetesParMinute(),
+  },
   adaptateurRechercheEntreprise,
   adaptateurProfilAnssi,
   entrepotResultatTest: new EntrepotResultatTestPostgres(),

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -68,8 +68,10 @@ export const configurationDeTestDuServeur: ConfigurationServeur = {
   adaptateurJWT: fauxAdaptateurJWT,
   adaptateurGestionErreur: adaptateurGestionVide,
   entrepotUtilisateur: new EntrepotUtilisateurMemoire(),
-  trustProxy: '0',
-  maxRequetesParMinutes: 3,
+  reseau: {
+    trustProxy: '0',
+    maxRequetesParMinutes: 3,
+  },
   busEvenements: fabriqueBusPourLesTests(),
   adaptateurRechercheEntreprise: fauxAdaptateurRechercheEntreprise,
   entrepotResultatTest: new EntrepotResultatTestMemoire(),

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -71,6 +71,7 @@ export const configurationDeTestDuServeur: ConfigurationServeur = {
   reseau: {
     trustProxy: '0',
     maxRequetesParMinutes: 3,
+    ipAutorisees: false,
   },
   busEvenements: fabriqueBusPourLesTests(),
   adaptateurRechercheEntreprise: fauxAdaptateurRechercheEntreprise,


### PR DESCRIPTION
On permet au serveur de filtrer les IPs qui ont le droit d'effectuer des requêtes.

Si le paramètre n'est pas positionné, aucun filtrage n'a lieu.

On adapte le gestionnaire d'erreur pour retourner 401 et terminer le traitement de la requête en cas de IpDenied