### PR TITLE
Corrige le filtrage IP

### DIFF
--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -61,8 +61,22 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
   app.use(limiteRequetesParMinute);
 
   if (configurationServeur.reseau.ipAutorisees) {
-    console.log(`On accepte uniquement les Ips: ${configurationServeur.reseau.ipAutorisees}`)
     app.use(IpFilter(configurationServeur.reseau.ipAutorisees, {
+      detectIp: (request) => {
+        const forwardedFor = request.headers['x-forwarded-for']
+        if (typeof forwardedFor === 'string') {
+          const ips = forwardedFor
+            .split(',')
+            .map(ip => ip.trim())
+            .filter(ip => ip !== '');
+
+          if (ips.length > 0) {
+            const ipWaf = ips[ips.length - 1];
+            return ipWaf;
+          }
+        }
+        return "interdire"
+      },
       mode: 'allow',
       log: false,
     }));


### PR DESCRIPTION
Lorsqu'on active le filtrage IP, on veut vérifier que les requêtes proviennent bien du WAF. Pour cela, on extrait la dernière IP de l'en-tête x-forwarded-for qui devrait être celle du WAF. Si ce n'est pas le cas, on rejette l'appel.

Plusieurs cas à la marge à traiter :
* x-forwarded-for peut être vide donc on vérifie que c'est une string
* la liste séparée par des virgules peut contenir des espaces donc on trim
* la liste pourrait contenir une IP vide donc on les filtre

Si on retourne une chaîne vide, IpFilter laisse passer la requête donc, par défaut, on retourne la chaîne "interdire" pour bloquer la requête.