### PR TITLE
Ajoute une vérification checkov de la configuration CI/CD

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -1,0 +1,38 @@
+# Vérification des recommandations CIS et autres sur les configurations GitHub
+# https://www.checkov.io/1.Welcome/What%20is%20Checkov.html
+# https://github.com/bridgecrewio/checkov-action
+---
+name: checkov
+permissions: {}
+on:
+  push:
+    branches: ['main', 'master']
+  pull_request:
+    branches: ['main', 'master']
+
+  workflow_dispatch:
+
+jobs:
+  scan:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Checkov GitHub Action
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+
+        if: success() || failure()
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/integration-continue.yml
+++ b/.github/workflows/integration-continue.yml
@@ -1,4 +1,5 @@
 name: L'intégration continue
+permissions: {}
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux; \
 # Installation de node
 RUN apk update && apk add nodejs npm
 
-ADD front /srv/jekyll
+COPY front /srv/jekyll
 
 # Build du catalogue
 WORKDIR /srv/jekyll/lib-svelte
@@ -74,11 +74,11 @@ FROM node:23 AS build-le-back
 RUN npm install -g npm
 WORKDIR /usr/src/app
 COPY back/package.json back/package-lock.json back/tsconfig.json back/knexfile.ts /usr/src/app/
-ADD back/src /usr/src/app/src
+COPY back/src /usr/src/app/src
 RUN npm install
 WORKDIR /usr/src/app/src
 RUN npx tsc
-ADD back/migrations /usr/src/dist-back/migrations
+COPY back/migrations /usr/src/dist-back/migrations
 
 ####
 ## SERVEUR

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,10 @@ COPY back/migrations /usr/src/dist-back/migrations
 FROM node:23-alpine
 EXPOSE 3000
 WORKDIR /usr/src/app
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+
 COPY package.json /usr/src/app/
 COPY --from=build-le-back /usr/src/app/node_modules/ /usr/src/app/node_modules/
 COPY --from=build-le-site /srv/jekyll/_site/ /usr/src/app/front/_site/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+#checkov:skip=CKV_DOCKER_2:Clever Cloud n'utiliser pas HEALTHCHECK
 #######################
 ## Dockerfile multi-staged, pour être utilisé à la fois par la CI/CD et par le PaaS de PROD.
 ## En CI/CD on veut simplement déclencher le `build` pour vérifier la validité du code


### PR DESCRIPTION
Le CIS propose un [benchmark](https://www.cisecurity.org/benchmark/software-supply-chain-security) pour la configuration sécurisée de GitHub et [checkov](https://www.checkov.io/1.Welcome/What%20is%20Checkov.html) valide automatiquement ces règles ainsi que quelques autres.

Cette PR met ces contrôles en place sur le projet avec [checkov-action](https://github.com/bridgecrewio/checkov-action).

Cette PR intègre également les changements nécessaires pour se conformer à ces recommandations :
* diminuer les permissions des jobs CI
* ignorer la règles sur docker HEALTHCHECK dans la mesure où Clever ne s'en sert pas
* créer un utilisateur dédié à l'exécution du serveur pour éviter de tourner en root