### PR TITLE
[CORRECTION] Ne réactive le bouton que si l'envoi du formulaire a échoué

### DIFF
--- a/front/lib-svelte/src/creation-compte/CreationCompte.svelte
+++ b/front/lib-svelte/src/creation-compte/CreationCompte.svelte
@@ -76,10 +76,10 @@
       try {
         enCoursEnvoi = true;
         await axios.post('/api/utilisateurs', formulaireInscription);
-      } finally {
+        window.location.href = '/oidc/connexion';
+      } catch (e) {
         enCoursEnvoi = false;
       }
-      window.location.href = '/oidc/connexion';
     }
   };
 


### PR DESCRIPTION
...sinon, on peut générer plusieurs fois le POST entre le moment où le premier est terminé et avant le redirect