### PR TITLE
[CORRECTION] Redirige vers `/ma-maturite` après l'envoi du test de maturité 

### DIFF
--- a/front/lib-svelte/src/test-maturite/TestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/TestMaturite.svelte
@@ -43,8 +43,10 @@
     const { id } = reponse.data;
     if (!await utilisateurEstConnecte()) {
       enregistreIdResultatTestPourRevendication(id);
+      afficheResultats = true;
+    } else {
+      window.location.href = '/ma-maturite';
     }
-    afficheResultats = true;
   }
 
   function debuteTeste() {


### PR DESCRIPTION
…en mode connecté