### PR TITLE
Corrige trust proxy (encore)

### DIFF
--- a/back/src/api/configurationServeur.ts
+++ b/back/src/api/configurationServeur.ts
@@ -20,7 +20,7 @@ export type ConfigurationServeur = {
   adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise;
   entrepotUtilisateur: EntrepotUtilisateur;
   reseau: {
-    trustProxy: string;
+    trustProxy: number|string;
     maxRequetesParMinutes: number;
     ipAutorisees: string[] | false;
   };

--- a/back/src/infra/adaptateurEnvironnement.ts
+++ b/back/src/infra/adaptateurEnvironnement.ts
@@ -9,7 +9,18 @@ const adaptateurEnvironnement = {
     clientSecret: () => process.env.OIDC_CLIENT_SECRET || '',
   }),
   serveur: () => ({
-    trustProxy: () => process.env.SERVEUR_TRUST_PROXY || '0',
+    trustProxy: () => {
+      const trustProxyEnChaine = process.env.SERVEUR_TRUST_PROXY || '0';
+      const trustProxyEnNombre = Number(trustProxyEnChaine);
+      if (isNaN(trustProxyEnNombre)) {
+        console.warn(
+          `Attention ! SERVEUR_TRUST_PROXY positionné à ${trustProxyEnChaine}`
+        );
+        return trustProxyEnChaine;
+      } else {
+        return trustProxyEnNombre;
+      }
+    },
     maxRequetesParMinute: () => {
       const maxEnChaine = process.env.SERVEUR_MAX_REQUETES_PAR_MINUTE || '600'
       const maxEnNombre = Number(maxEnChaine);


### PR DESCRIPTION
`trust proxy` accepte vraiment beaucoup de types d'options différentes. En général, on souhaite lui passer un nombre mais le code passait en fait une chaîne de caractère.

Autrement dit, `1` en variable d'environnement devenait `'1'` et n'était pas interprété comme un nombre de proxy mais comme, je suppose, l'IP du proxy.

Après pas mal de tests en local, cette version semble enfin fonctionner.

Cf. https://expressjs.com/en/guide/behind-proxies.html