### PR TITLE
Ordonne les items du catalogue sans filtre sur le besoin cyber.

### DIFF
--- a/front/_data/catalogue.yml
+++ b/front/_data/catalogue.yml
@@ -64,7 +64,6 @@ TOUS:
 - /ressources/visa-secu
 - /ressources/visa-secu-produit
 - /ressources/livret-cyber-enjeux
-- /ressources/revue-presse
 - /ressources/guides-gestion-crise
 - /ressources/guides-remediation
 - /services/assistance-technique
@@ -78,11 +77,9 @@ TOUS:
 - /ressources/prestas-ebios
 - /ressources/publications
 - /ressources/nl-industries
-- /services/cot
 - /services/assistance-reponse-incidents
 - /services/transmission-signalements
-- /ressources/revue-presse
-- /ressources/risques-cyber   
+- /ressources/revue-presse 
 - /ressources/avis-bulletin
 - /ressources/rapport-menace
 - /services/secnum-academie
@@ -99,7 +96,5 @@ TOUS:
 - /ressources/cybermalveillance
 - /services/sens-cyber
 - /ressources/malette-cyber
-- /ressources/cnil-reco
-- /ressources/cnil-ensemble
 - /ressources/cnil-reco
 - /ressources/cnil-ensemble

--- a/front/_data/catalogue.yml
+++ b/front/_data/catalogue.yml
@@ -54,47 +54,52 @@ SE_FORMER:
   - /ressources/risques-cyber
   - /ressources/revue-presse
 TOUS:
-  - /ressources/livret-cyber-enjeux
-  - /services/secnum-academie
-  - /ressources/secnumedu
-  - /ressources/secnumedufc
-  - /services/demainspecialistecyber
-  - /services/demainspecialistecyber-affiches
-  - /services/pix
-  - /services/hackropole
-  - /ressources/cyber-dico
-  - /ressources/risques-cyber
-  - /ressources/revue-presse
-  - /services/assistance-reponse-incidents
-  - /services/cot
-  - /ressources/guides-gestion-crise
-  - /ressources/guides-remediation
-  - /services/diagnostic-17cyber
-  - /ressources/avis-bulletin
-  - /ressources/rapport-menace
-  - /services/transmission-signalements
-  - /services/mon-aide-cyber
-  - /services/mon-aide-cyber-aidants
-  - /services/mon-service-securise
-  - /services/ads
-  - /services/silene
-  - /ressources/guides-hygiene
-  - /ressources/cyber-13questions
-  - /ressources/ebios
-  - /ressources/prestas-ebios
-  - /ressources/visa-secu
-  - /ressources/visa-secu-produit
-  - /ressources/label-expert-cyber
-  - /services/assistance-technique
-  - /services/mon-espace-nis2
-  - /services/NIS2
-  - /ressources/publications
-  - /ressources/nl-industries
-  - /services/conseil-technique
-  - /services/pack-parcours-secu
-  - /ressources/panorama
-  - /services/sens-cyber
-  - /ressources/malette-cyber
-  - /ressources/cybermalveillance
-  - /ressources/cnil-reco
-  - /ressources/cnil-ensemble
+- /ressources/risques-cyber
+- /services/mon-aide-cyber
+- /services/mon-espace-nis2
+- /services/NIS2
+- /services/mon-service-securise
+- /ressources/cyber-13questions
+- /ressources/guides-hygiene
+- /ressources/visa-secu
+- /ressources/visa-secu-produit
+- /ressources/livret-cyber-enjeux
+- /ressources/revue-presse
+- /ressources/guides-gestion-crise
+- /ressources/guides-remediation
+- /services/assistance-technique
+- /services/conseil-technique
+- /services/mon-aide-cyber-aidants
+- /ressources/panorama
+- /services/ads
+- /services/silene
+- /services/cot   
+- /ressources/ebios
+- /ressources/prestas-ebios
+- /ressources/publications
+- /ressources/nl-industries
+- /services/cot
+- /services/assistance-reponse-incidents
+- /services/transmission-signalements
+- /ressources/revue-presse
+- /ressources/risques-cyber   
+- /ressources/avis-bulletin
+- /ressources/rapport-menace
+- /services/secnum-academie
+- /ressources/secnumedu
+- /ressources/secnumedufc
+- /services/demainspecialistecyber
+- /services/demainspecialistecyber-affiches
+- /services/pix
+- /services/hackropole
+- /ressources/cyber-dico
+- /services/pack-parcours-secu
+- /ressources/label-expert-cyber
+- /services/diagnostic-17cyber
+- /ressources/cybermalveillance
+- /services/sens-cyber
+- /ressources/malette-cyber
+- /ressources/cnil-reco
+- /ressources/cnil-ensemble
+- /ressources/cnil-reco
+- /ressources/cnil-ensemble

--- a/front/_data/catalogue.yml
+++ b/front/_data/catalogue.yml
@@ -41,7 +41,6 @@ REAGIR:
   - /ressources/avis-bulletin
   - /ressources/rapport-menace
   - /services/transmission-signalements
-
 SE_FORMER:
   - /ressources/livret-cyber-enjeux
   - /services/secnum-academie
@@ -54,3 +53,48 @@ SE_FORMER:
   - /ressources/cyber-dico
   - /ressources/risques-cyber
   - /ressources/revue-presse
+TOUS:
+  - /ressources/livret-cyber-enjeux
+  - /services/secnum-academie
+  - /ressources/secnumedu
+  - /ressources/secnumedufc
+  - /services/demainspecialistecyber
+  - /services/demainspecialistecyber-affiches
+  - /services/pix
+  - /services/hackropole
+  - /ressources/cyber-dico
+  - /ressources/risques-cyber
+  - /ressources/revue-presse
+  - /services/assistance-reponse-incidents
+  - /services/cot
+  - /ressources/guides-gestion-crise
+  - /ressources/guides-remediation
+  - /services/diagnostic-17cyber
+  - /ressources/avis-bulletin
+  - /ressources/rapport-menace
+  - /services/transmission-signalements
+  - /services/mon-aide-cyber
+  - /services/mon-aide-cyber-aidants
+  - /services/mon-service-securise
+  - /services/ads
+  - /services/silene
+  - /ressources/guides-hygiene
+  - /ressources/cyber-13questions
+  - /ressources/ebios
+  - /ressources/prestas-ebios
+  - /ressources/visa-secu
+  - /ressources/visa-secu-produit
+  - /ressources/label-expert-cyber
+  - /services/assistance-technique
+  - /services/mon-espace-nis2
+  - /services/NIS2
+  - /ressources/publications
+  - /ressources/nl-industries
+  - /services/conseil-technique
+  - /services/pack-parcours-secu
+  - /ressources/panorama
+  - /services/sens-cyber
+  - /ressources/malette-cyber
+  - /ressources/cybermalveillance
+  - /ressources/cnil-reco
+  - /ressources/cnil-ensemble

--- a/front/_includes/script-donnees-json.html
+++ b/front/_includes/script-donnees-json.html
@@ -23,7 +23,8 @@
       "ETRE_SENSIBILISE": {% include tableau-json.html tableau=include.repartition.ETRE_SENSIBILISE %},
       "REAGIR": {% include tableau-json.html tableau=include.repartition.REAGIR %},
       "SE_FORMER": {% include tableau-json.html tableau=include.repartition.SE_FORMER %},
-      "SECURISER": {% include tableau-json.html tableau=include.repartition.SECURISER %}
+      "SECURISER": {% include tableau-json.html tableau=include.repartition.SECURISER %},
+      "TOUS": {% include tableau-json.html tableau=include.repartition.TOUS %}
     }
   }
 </script>

--- a/front/lib-svelte/src/catalogue/Catalogue.types.ts
+++ b/front/lib-svelte/src/catalogue/Catalogue.types.ts
@@ -18,6 +18,7 @@ export enum BesoinCyber {
   ETRE_SENSIBILISE = "ETRE_SENSIBILISE",
   SE_FORMER = "SE_FORMER",
   SECURISER = "SECURISER",
+  TOUS = "TOUS"
 }
 
 export type RepartitionParBesoin = Record<BesoinCyber, IdItemCyber[]>;

--- a/front/lib-svelte/src/catalogue/stores/catalogue.store.ts
+++ b/front/lib-svelte/src/catalogue/stores/catalogue.store.ts
@@ -8,6 +8,7 @@ const { subscribe, set } = writable({
     SECURISER: [],
     ETRE_SENSIBILISE: [],
     SE_FORMER: [],
+    TOUS:[]
   },
 } as { items: ItemCyber[]; repartition: RepartitionParBesoin });
 

--- a/front/lib-svelte/src/catalogue/stores/catalogueParBesoin.ts
+++ b/front/lib-svelte/src/catalogue/stores/catalogueParBesoin.ts
@@ -1,16 +1,14 @@
-import { derived } from "svelte/store";
-import { catalogueStore } from "./catalogue.store";
-import { rechercheParBesoin } from "./rechercheParBesoin.store";
+import { derived } from 'svelte/store';
+import { catalogueStore } from './catalogue.store';
+import { rechercheParBesoin } from './rechercheParBesoin.store';
+import { BesoinCyber } from '../Catalogue.types';
 
 export const catalogueParBesoin = derived(
   [catalogueStore, rechercheParBesoin],
   ([$catalogueStore, $rechercheParBesoin]) => {
-    if (!$rechercheParBesoin) {
-      return $catalogueStore.items;
-    }
-
-    return $catalogueStore.repartition[$rechercheParBesoin]
+    let besoinCyber = $rechercheParBesoin ? $rechercheParBesoin : BesoinCyber.TOUS;
+    return $catalogueStore.repartition[besoinCyber]
       .map((id) => $catalogueStore.items.find((i) => i.id === id))
       .filter((i) => i !== undefined);
-  },
+  }
 );

--- a/front/lib-svelte/test/catalogue/stores/catalogueFiltre.store.spec.ts
+++ b/front/lib-svelte/test/catalogue/stores/catalogueFiltre.store.spec.ts
@@ -1,29 +1,30 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { get } from "svelte/store";
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
 import {
   demainSpecialisteCyber,
   guidesTechniques,
   kitCyber,
   livretEnJeux,
   mss,
-} from "./objetsExemples";
-import { catalogueStore } from "../../../src/catalogue/stores/catalogue.store";
-import { rechercheParBesoin } from "../../../src/catalogue/stores/rechercheParBesoin.store";
-import { catalogueFiltre } from "../../../src/catalogue/stores/catalogueFiltre.store";
-import { rechercheParDroitAcces } from "../../../src/catalogue/stores/rechercheParDroitAcces.store";
+} from './objetsExemples';
+import { catalogueStore } from '../../../src/catalogue/stores/catalogue.store';
+import { rechercheParBesoin } from '../../../src/catalogue/stores/rechercheParBesoin.store';
+import { catalogueFiltre } from '../../../src/catalogue/stores/catalogueFiltre.store';
+import { rechercheParDroitAcces } from '../../../src/catalogue/stores/rechercheParDroitAcces.store';
 import {
   BesoinCyber,
   DroitAcces,
   FormatRessource,
+  ItemCyber,
   Source,
   Typologie,
-} from "../../../src/catalogue/Catalogue.types";
-import { rechercheParTypologie } from "../../../src/catalogue/stores/rechercheParTypologie.store";
-import { rechercheParFormat } from "../../../src/catalogue/stores/rechercheParFormat.store";
-import { rechercheParSource } from "../../../src/catalogue/stores/rechercheParSource.store";
-import { limitationRecherche } from "../../../src/catalogue/stores/limitationRecherche";
+} from '../../../src/catalogue/Catalogue.types';
+import { rechercheParTypologie } from '../../../src/catalogue/stores/rechercheParTypologie.store';
+import { rechercheParFormat } from '../../../src/catalogue/stores/rechercheParFormat.store';
+import { rechercheParSource } from '../../../src/catalogue/stores/rechercheParSource.store';
+import { limitationRecherche } from '../../../src/catalogue/stores/limitationRecherche';
 
-describe("Le store du catalogue filtré", () => {
+describe('Le store du catalogue filtré', () => {
   beforeEach(() => {
     rechercheParBesoin.set(null);
     rechercheParDroitAcces.set([]);
@@ -33,61 +34,64 @@ describe("Le store du catalogue filtré", () => {
     limitationRecherche.set(0);
   });
 
-  const repartitionVide = () => ({
-    REAGIR: [],
-    SE_FORMER: [],
-    SECURISER: [],
-    ETRE_SENSIBILISE: [],
-  });
+  const initialiseStoreCatalogue = (tous: ItemCyber[]) => {
+    catalogueStore.initialise(tous, {
+      REAGIR: [],
+      SE_FORMER: [],
+      SECURISER: [],
+      ETRE_SENSIBILISE: [],
+      TOUS: tous.map((item) => item.id),
+    });
+  };
 
   describe("sur application d'un filtre de besoin", () => {
-    it("conserve uniquement les items correspondants", () => {
+    it('conserve uniquement les items correspondants', () => {
       catalogueStore.initialise([mss(), demainSpecialisteCyber()], {
         REAGIR: [],
         SE_FORMER: [],
-        SECURISER: ["/services/mss"],
+        SECURISER: ['/services/mss'],
         ETRE_SENSIBILISE: [],
+        TOUS: [],
       });
       rechercheParBesoin.set(BesoinCyber.SECURISER);
 
       const { resultats } = get(catalogueFiltre);
 
       expect(resultats.length).toBe(1);
-      expect(resultats[0].nom).toBe("mss");
+      expect(resultats[0].nom).toBe('mss');
     });
 
     it("conserve tous les items en cas d'absence de besoins", () => {
-      catalogueStore.initialise(
-        [mss(), demainSpecialisteCyber()],
-        repartitionVide(),
-      );
+      const repartition = {
+        REAGIR: [],
+        SE_FORMER: [],
+        SECURISER: [],
+        ETRE_SENSIBILISE: [],
+        TOUS: ['/services/demainspecialistecyber', '/services/mss'],
+      };
+      catalogueStore.initialise([mss(), demainSpecialisteCyber()], repartition);
       rechercheParBesoin.set(null);
 
       const { resultats } = get(catalogueFiltre);
 
       expect(resultats.length).toBe(2);
+      expect(resultats[0].id).toEqual('/services/demainspecialistecyber');
     });
   });
 
   describe("sur application d'un filtre d'accessibilité", () => {
-    it("conserve uniquement les items correspondants", () => {
-      catalogueStore.initialise(
-        [mss(), demainSpecialisteCyber()],
-        repartitionVide(),
-      );
+    it('conserve uniquement les items correspondants', () => {
+      initialiseStoreCatalogue([mss(), demainSpecialisteCyber()]);
       rechercheParDroitAcces.set([DroitAcces.ACCES_LIBRE]);
 
       const { resultats } = get(catalogueFiltre);
 
       expect(resultats.length).toBe(1);
-      expect(resultats[0].nom).toBe("DemainSpécialisteCyber");
+      expect(resultats[0].nom).toBe('DemainSpécialisteCyber');
     });
 
     it("conserve tous les items en cas d'absence de droits d'acces", () => {
-      catalogueStore.initialise(
-        [mss(), demainSpecialisteCyber()],
-        repartitionVide(),
-      );
+      initialiseStoreCatalogue([mss(), demainSpecialisteCyber()]);
       rechercheParDroitAcces.set([]);
 
       const { resultats } = get(catalogueFiltre);
@@ -97,18 +101,18 @@ describe("Le store du catalogue filtré", () => {
   });
 
   describe("sur application d'un filtre de typologie", () => {
-    it("peut conserver uniquement les services", () => {
-      catalogueStore.initialise([mss(), livretEnJeux()], repartitionVide());
+    it('peut conserver uniquement les services', () => {
+      initialiseStoreCatalogue([mss(), livretEnJeux()]);
       rechercheParTypologie.set([Typologie.SERVICE]);
 
       const { resultats } = get(catalogueFiltre);
 
       expect(resultats.length).toBe(1);
-      expect(resultats[0].nom).toBe("mss");
+      expect(resultats[0].nom).toBe('mss');
     });
 
-    it("conserve tous les items quand aucun filtre actif", () => {
-      catalogueStore.initialise([mss(), livretEnJeux()], repartitionVide());
+    it('conserve tous les items quand aucun filtre actif', () => {
+      initialiseStoreCatalogue([mss(), livretEnJeux()]);
       rechercheParTypologie.set([]);
 
       const { resultats } = get(catalogueFiltre);
@@ -118,24 +122,18 @@ describe("Le store du catalogue filtré", () => {
   });
 
   describe("sur application d'un filtre de format", () => {
-    it("conserve uniquement les items correspondant", () => {
-      catalogueStore.initialise(
-        [livretEnJeux(), guidesTechniques()],
-        repartitionVide(),
-      );
+    it('conserve uniquement les items correspondant', () => {
+      initialiseStoreCatalogue([livretEnJeux(), guidesTechniques()]);
       rechercheParFormat.set([FormatRessource.PUBLICATION]);
 
       const { resultats } = get(catalogueFiltre);
 
       expect(resultats.length).toBe(1);
-      expect(resultats[0].nom).toBe("Guides techniques");
+      expect(resultats[0].nom).toBe('Guides techniques');
     });
 
-    it("conserve tous les items quand aucun filtre actif", () => {
-      catalogueStore.initialise(
-        [livretEnJeux(), guidesTechniques()],
-        repartitionVide(),
-      );
+    it('conserve tous les items quand aucun filtre actif', () => {
+      initialiseStoreCatalogue([livretEnJeux(), guidesTechniques()]);
       rechercheParFormat.set([]);
 
       const { resultats } = get(catalogueFiltre);
@@ -146,21 +144,18 @@ describe("Le store du catalogue filtré", () => {
 
   describe("sur application d'un filtre de source", () => {
     // d'autres tests plus spécifiques sont dans rechercheParSource.store.spec
-    it("conserve uniquement les items correspondants", () => {
-      catalogueStore.initialise([mss(), kitCyber()], repartitionVide());
+    it('conserve uniquement les items correspondants', () => {
+      initialiseStoreCatalogue([mss(), kitCyber()]);
       rechercheParSource.set([Source.PARTENAIRES]);
 
       const { resultats } = get(catalogueFiltre);
 
       expect(resultats.length).toBe(1);
-      expect(resultats[0].nom).toBe("KIT CYBER");
+      expect(resultats[0].nom).toBe('KIT CYBER');
     });
 
     it("conserve tous les items en cas d'absence de source", () => {
-      catalogueStore.initialise(
-        [mss(), demainSpecialisteCyber()],
-        repartitionVide(),
-      );
+      initialiseStoreCatalogue([mss(), demainSpecialisteCyber()]);
       rechercheParSource.set([]);
 
       const { resultats } = get(catalogueFiltre);
@@ -169,12 +164,9 @@ describe("Le store du catalogue filtré", () => {
     });
   });
 
-  describe("sur limitation du nombre de résultats", () => {
-    it("ne conserve que les x premiers éléments", () => {
-      catalogueStore.initialise(
-        [mss(), demainSpecialisteCyber()],
-        repartitionVide(),
-      );
+  describe('sur limitation du nombre de résultats', () => {
+    it('ne conserve que les x premiers éléments', () => {
+      initialiseStoreCatalogue([mss(), demainSpecialisteCyber()]);
       limitationRecherche.set(1);
 
       const { resultats } = get(catalogueFiltre);


### PR DESCRIPTION
Les produits sont désormais triés en suivant l’ordre de tri spécifié dans le fichier catalogue.yml