### PR TITLE
Corrige les derniers liens avec le bon style

### DIFF
--- a/front/assets/styles/service.scss
+++ b/front/assets/styles/service.scss
@@ -343,14 +343,6 @@ h2 {
   }
 
   a {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    line-height: 1.5rem;
-    text-decoration: none;
-    color: var(--noir);
-    border-bottom: 1px solid var(--noir);
-
     &:before {
       content: '';
       background: url('/assets/images/icone-fleche-pleine.svg');

--- a/front/lib-svelte/src/creation-compte/CreationCompte.svelte
+++ b/front/lib-svelte/src/creation-compte/CreationCompte.svelte
@@ -258,7 +258,7 @@
                 use:validationChamp={'Ce champ est obligatoire. Veuillez le cocher.'}
               />
               <label for="cguAcceptees" class="requis">
-                J'accepte les <a href="/cgu">
+                J'accepte les <a class="lien" href="/cgu">
                   conditions générales d'utilisation
                 </a> de MesServicesCyber
               </label>


### PR DESCRIPTION
On utilise un "text-decoration underline" sur un lien au lieu d'un border-bottom pour stylise correctement et conformément au reste de l'application.
Cela évite d'avoir une effet d'espacement/clignotement au survole du lien.