### PR TITLE
[SOIN] Enlève la répartition des besoins pour les favoris

### DIFF
--- a/front/_includes/script-donnees-json.html
+++ b/front/_includes/script-donnees-json.html
@@ -18,7 +18,9 @@
     }
       {% unless forloop.last %},{% endunless %}
       {% endfor %}
-    ],
+    ]
+    {% if include.repartition %}
+    ,
     "repartition": {
       "ETRE_SENSIBILISE": {% include tableau-json.html tableau=include.repartition.ETRE_SENSIBILISE %},
       "REAGIR": {% include tableau-json.html tableau=include.repartition.REAGIR %},
@@ -26,5 +28,6 @@
       "SECURISER": {% include tableau-json.html tableau=include.repartition.SECURISER %},
       "TOUS": {% include tableau-json.html tableau=include.repartition.TOUS %}
     }
+    {% endif %}
   }
 </script>

--- a/front/favoris-partages.html
+++ b/front/favoris-partages.html
@@ -4,7 +4,7 @@ permalink: /favoris-partages/
 titreHtml: 'Favoris partagés | MesServicesCyber'
 ---
 
-{% include script-donnees-json.html repartition=site.data.catalogue %}
+{% include script-donnees-json.html %}
 
 <script
   type="module"

--- a/front/favoris.html
+++ b/front/favoris.html
@@ -4,7 +4,7 @@ permalink: /favoris/
 titreHtml: 'Vos favoris | MesServicesCyber'
 ---
 
-{% include script-donnees-json.html repartition=site.data.catalogue %}
+{% include script-donnees-json.html %}
 
 <script
   type="module"

--- a/front/lib-svelte/src/catalogue/stores/catalogue.store.ts
+++ b/front/lib-svelte/src/catalogue/stores/catalogue.store.ts
@@ -1,19 +1,25 @@
-import { writable } from "svelte/store";
-import { type ItemCyber, type RepartitionParBesoin } from "../Catalogue.types";
+import { writable } from 'svelte/store';
+import { type ItemCyber, type RepartitionParBesoin } from '../Catalogue.types';
+
+const repartitionVide = {
+  REAGIR: [],
+  SECURISER: [],
+  SE_FORMER: [],
+  ETRE_SENSIBILISE: [],
+  TOUS: [],
+};
 
 const { subscribe, set } = writable({
   items: [],
-  repartition: {
-    REAGIR: [],
-    SECURISER: [],
-    ETRE_SENSIBILISE: [],
-    SE_FORMER: [],
-    TOUS:[]
-  },
+  repartition: repartitionVide,
 } as { items: ItemCyber[]; repartition: RepartitionParBesoin });
 
 export const catalogueStore = {
   subscribe,
-  initialise: (itemsCyber: ItemCyber[], repartition: RepartitionParBesoin) =>
-    set({ items: [...itemsCyber], repartition }),
+  initialise: (itemsCyber: ItemCyber[], repartition?: RepartitionParBesoin) => {
+    set({
+      items: [...itemsCyber],
+      repartition: repartition ?? repartitionVide,
+    });
+  },
 };

--- a/front/lib-svelte/src/main-favoris-partages.ts
+++ b/front/lib-svelte/src/main-favoris-partages.ts
@@ -1,18 +1,14 @@
 import { mount } from 'svelte';
-import type { ItemCyber, RepartitionParBesoin } from "./catalogue/Catalogue.types";
-import { catalogueStore } from "./catalogue/stores/catalogue.store";
-import FavorisPartages from "./favoris/FavorisPartages.svelte";
+import type { ItemCyber } from './catalogue/Catalogue.types';
+import { catalogueStore } from './catalogue/stores/catalogue.store';
+import FavorisPartages from './favoris/FavorisPartages.svelte';
 
+const donnees = document.getElementById('donnees')!.textContent;
+if (!donnees) throw new Error('Impossible de trouver les données du catalogue');
 
-const donnees = document.getElementById("donnees")!.textContent;
-if (!donnees) throw new Error("Impossible de trouver les données du catalogue");
+const { itemsCyber } = JSON.parse(donnees) as { itemsCyber: ItemCyber[] };
 
-const { itemsCyber, repartition } = JSON.parse(donnees) as {
-  itemsCyber: ItemCyber[];
-  repartition: RepartitionParBesoin;
-};
-
-catalogueStore.initialise(itemsCyber, repartition);
+catalogueStore.initialise(itemsCyber);
 
 const favorisPartages = mount(FavorisPartages, {
   target: document.getElementById('favoris-partages')!,

--- a/front/lib-svelte/src/main-favoris.ts
+++ b/front/lib-svelte/src/main-favoris.ts
@@ -1,18 +1,14 @@
 import { mount } from 'svelte';
-import MesFavoris from "./favoris/MesFavoris.svelte";
-import type { ItemCyber, RepartitionParBesoin } from "./catalogue/Catalogue.types";
-import { catalogueStore } from "./catalogue/stores/catalogue.store";
+import MesFavoris from './favoris/MesFavoris.svelte';
+import type { ItemCyber } from './catalogue/Catalogue.types';
+import { catalogueStore } from './catalogue/stores/catalogue.store';
 
+const donnees = document.getElementById('donnees')!.textContent;
+if (!donnees) throw new Error('Impossible de trouver les données du catalogue');
 
-const donnees = document.getElementById("donnees")!.textContent;
-if (!donnees) throw new Error("Impossible de trouver les données du catalogue");
+const { itemsCyber } = JSON.parse(donnees) as { itemsCyber: ItemCyber[] };
 
-const { itemsCyber, repartition } = JSON.parse(donnees) as {
-  itemsCyber: ItemCyber[];
-  repartition: RepartitionParBesoin;
-};
-
-catalogueStore.initialise(itemsCyber, repartition);
+catalogueStore.initialise(itemsCyber);
 
 const favoris = mount(MesFavoris, {
   target: document.getElementById('favoris')!,


### PR DESCRIPTION
La répartition des besoins est nécessaire pour l’affichage du catalogue ou de l’extrait en fonction des besoins cyber. Les favoris n’ont pas besoin de cette répartition. 