### PR TITLE
fiche-conseil-technique

### DIFF
--- a/front/_layouts/service.html
+++ b/front/_layouts/service.html
@@ -29,8 +29,10 @@ script: /scripts/service.js
         <span class="badge service">Service</span>
         <h1>{{page.nom}}</h1>
         <p>{{page.description}}</p>
+        {% if page.lien %}
         <a href="{{page.lien}}" target="_blank" class="bouton primaire lien-externe-produit" data-source="Page produit"
            data-cible="{{page.nom}}">Accéder au service</a>
+        {%endif%}
       </div>
       <div class="conteneur-illustration">
         <img src="/assets/images/illustrations-services/{{ page.illustration }}" alt="Capture d’écran" />
@@ -86,8 +88,10 @@ script: /scripts/service.js
         </div>
         <h2>De quoi s'agit-il&nbsp;?</h2>
         <div>{{ page.content }}</div>
+        {% if page.lien %}
         <a href="{{page.lien}}" target="_blank" class="bouton primaire lien-externe-produit" data-source="Page produit"
            data-cible="{{page.nom}}">Accéder au service</a>
+        {% endif %}
       </section>
 
       <section class="cible" id="cible">

--- a/front/_services/conseil-technique.md
+++ b/front/_services/conseil-technique.md
@@ -5,10 +5,16 @@ nom: Conseil Technique
 description: Poser une question technique
 titreHtml: Conseil Technique
 illustration: conseil-technique/conseil-technique.png
+avecFicheDetaillee: true
 lien: Mailto:conseil.technique@ssi.gouv.fr
 droitsAcces:
   - ENTITES_PUBLIQUES
   - REGULES_NIS2
 sources:
   - ANSSI
+cible: |
+  <ul>
+  Le service conseil technique est accessible à tous.
+  </ul>
 ---
+Pour toute question simple portant sur les guides techniques publiés par l’ANSSI, posez une question en envoyant un mail à `conseil.technique [at] ssi.gouv.fr`.

--- a/front/_services/conseil-technique.md
+++ b/front/_services/conseil-technique.md
@@ -6,7 +6,6 @@ description: Poser une question technique
 titreHtml: Conseil Technique
 illustration: conseil-technique/conseil-technique.png
 avecFicheDetaillee: true
-lien: Mailto:conseil.technique@ssi.gouv.fr
 droitsAcces:
   - ENTITES_PUBLIQUES
   - REGULES_NIS2

--- a/front/assets/styles/site.scss
+++ b/front/assets/styles/site.scss
@@ -907,3 +907,9 @@ select {
   position: relative;
   box-shadow: 0px 2px 6px 0px rgba(0, 0, 18, 0.16);
 }
+
+code {
+  background: rgba(0,0,0,.1);
+  padding-left: 3px;
+  padding-right: 3px;
+}


### PR DESCRIPTION
Cette PR modifie la description du service, et masque le bouton qui était un `mailto` 👇 


![image](https://github.com/user-attachments/assets/d655ebbb-9e5d-429a-8d62-4e93845eb338)

Ce service ne souhaite pas avoir de lien `mailto` sur sa page.