### PR TITLE
Corrige des erreurs Sentry

### DIFF
--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -32,7 +32,7 @@ const adaptateurMonAideCyber = fabriqueAdaptateurMonAideCyber();
 
 creeServeur({
   fournisseurChemin,
-  middleware: fabriqueMiddleware({ adaptateurJWT }),
+  middleware: fabriqueMiddleware({ adaptateurJWT, fournisseurChemin }),
   adaptateurOIDC,
   adaptateurJWT,
   adaptateurGestionErreur: adaptateurGestionErreurSentry,

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -52,8 +52,10 @@ export const fauxAdaptateurProfilAnssi: AdaptateurProfilAnssi = {
 };
 
 export const fauxMiddleware: Middleware = {
-  ajouteMethodeNonce: fabriqueMiddleware({ adaptateurJWT: fauxAdaptateurJWT })
-    .ajouteMethodeNonce,
+  ajouteMethodeNonce: fabriqueMiddleware({
+    adaptateurJWT: fauxAdaptateurJWT,
+    fournisseurChemin: fauxFournisseurDeChemin,
+  }).ajouteMethodeNonce,
   positionneLesCsp: () => async (_, __, suite) => {
     suite();
   },
@@ -78,7 +80,10 @@ const fauxAdaptateurMonAideCyber = { creeDemandeAide: () => Promise.resolve() };
 
 export const configurationDeTestDuServeur: ConfigurationServeur = {
   fournisseurChemin: fauxFournisseurDeChemin,
-  middleware: fabriqueMiddleware({ adaptateurJWT: fauxAdaptateurJWT }),
+  middleware: fabriqueMiddleware({
+    adaptateurJWT: fauxAdaptateurJWT,
+    fournisseurChemin: fauxFournisseurDeChemin,
+  }),
   adaptateurOIDC: fauxAdaptateurOIDC,
   adaptateurJWT: fauxAdaptateurJWT,
   adaptateurGestionErreur: adaptateurGestionVide,

--- a/front/scripts/service.js
+++ b/front/scripts/service.js
@@ -14,7 +14,7 @@ const trouveLesLiDesSommaires = (hash) =>
   );
 
 const trouveLeTexte = (hash) =>
-  trouveLesLiDuSommaireReplie(hash)[0].textContent;
+  trouveLesLiDuSommaireReplie(hash)[0]?.textContent;
 
 const desactiveTousLesItems = () => {
   const sections = Array.from(document.querySelectorAll('.sommaire ul li'));


### PR DESCRIPTION
Correctif appliqués pour les erreurs suivantes: 
- Evite au js de casser lors de la construction du sommaire si un de ces éléments n'a pas de `textContent`
    - https://sentry.incubateur.net/organizations/betagouv/issues/165743/?project=221&referrer=webhooks_plugin
- Ajoute une gestion d'erreur lors que l'utilisateur tente d'accéder à une ressource qui n'existe pas et renvoi vers la page d'erreur 404 au lieu de tomber dans la page 500 de Baleen
    - https://sentry.incubateur.net/organizations/betagouv/issues/164107/?project=221&query=is%3Aunresolved&referrer=issue-stream&stream_index=1 