### PR TITLE
[CORRECTION] Corrige les types Axios au niveau de lib-svelte

### DIFF
--- a/front/lib-svelte/package.json
+++ b/front/lib-svelte/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tsconfig/svelte": "^5.0.4",
-    "@types/axios": "^0.9.36",
     "eslint": "^9.23.0",
     "eslint-plugin-svelte": "^3.5.0",
     "globals": "^16.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
         "@tsconfig/svelte": "^5.0.4",
-        "@types/axios": "^0.9.36",
         "eslint": "^9.23.0",
         "eslint-plugin-svelte": "^3.5.0",
         "globals": "^16.0.0",
@@ -1453,13 +1452,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.4.tgz",
       "integrity": "sha512-BV9NplVgLmSi4mwKzD8BD/NQ8erOY/nUE/GpgWe2ckx+wIQF5RyRirn/QsSSCPeulVpc3RA/iJt6DpfTIZps0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/axios": {
-      "version": "0.9.36",
-      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.9.36.tgz",
-      "integrity": "sha512-NLOpedx9o+rxo/X5ChbdiX6mS1atE4WHmEEIcR9NLenRVa5HoVjAvjafwU3FPTqnZEstpoqCaW7fagqSoTDNeg==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
... suite à la montée de version Dependabot la dépendance "@types/axios" casse le typage Typescript dans le svelte.