### PR TITLE
[SOIN] N'envoie pas l'email de l'Aidant précédemment renseigné si la personne change d'avis et sélectionne "Non" dans le formulaire de demande d'Aide MonAideCyber

### DIFF
--- a/front/lib-svelte/src/demande-aide-mon-aide-cyber/DonneesFormulaireDemandeAide.ts
+++ b/front/lib-svelte/src/demande-aide-mon-aide-cyber/DonneesFormulaireDemandeAide.ts
@@ -2,7 +2,7 @@ import type { Organisation } from '../ui/formulaire/SelectionOrganisation.types'
 
 export type DonneesFormulaireDemandeAide = {
   email: string;
-  emailAidant: string;
+  emailAidant?: string;
   entite: Organisation;
   cguSontValidees: boolean;
 };

--- a/front/lib-svelte/src/demande-aide-mon-aide-cyber/FormulaireDemandeAide.svelte
+++ b/front/lib-svelte/src/demande-aide-mon-aide-cyber/FormulaireDemandeAide.svelte
@@ -32,7 +32,7 @@
     emets('formulaireSoumis', {
       entite,
       email,
-      emailAidant,
+      ...(estEnRelationAvecUnUtilisateur && { emailAidant }),
       cguSontValidees,
     });
   };


### PR DESCRIPTION
Reproduction :

- Remplir le formulaire de Demande d'Aide sur /cyberdepart
- Répondre "Oui" à la question : Êtes-vous déjà en contact avec un Aidant cyber ou un prestataire ?
- Renseigner un email d'Aidant cyber
- Répondre "Non" à la même question
- Soumettre le formulaire

On constate que le front fourni à l'API l'emailAidant précédemment rempli, sauf que l'utilisateur vient de se rétracter en répondant "Non"

Une correction facile consiste à ne pas envoyer à l'event emitter le champ emailAidant si le state `estEnRelationAvecUnUtilisateur !== true`