### PR TITLE
Déplace la console d’administration

### DIFF
--- a/back/src/admin/consoleAdministration.ts
+++ b/back/src/admin/consoleAdministration.ts
@@ -1,11 +1,11 @@
 import { AxiosError } from 'axios';
-import { EntrepotUtilisateurMPAPostgres } from '../src/infra/entrepotUtilisateurMPAPostgres';
-import { EntrepotUtilisateur } from '../src/metier/entrepotUtilisateur';
-import { fabriqueAdaptateurProfilAnssi } from '../src/infra/adaptateurProfilAnssi';
-import { adaptateurRechercheEntreprise } from '../src/infra/adaptateurRechercheEntreprise';
-import { Utilisateur } from '../src/metier/utilisateur';
-import { AdaptateurEmail } from '../src/metier/adaptateurEmail';
-import { fabriqueAdaptateurEmail } from '../src/infra/adaptateurEmailBrevo';
+import { EntrepotUtilisateur } from '../metier/entrepotUtilisateur';
+import { AdaptateurEmail } from '../metier/adaptateurEmail';
+import { fabriqueAdaptateurProfilAnssi } from '../infra/adaptateurProfilAnssi';
+import { EntrepotUtilisateurMPAPostgres } from '../infra/entrepotUtilisateurMPAPostgres';
+import { fabriqueAdaptateurEmail } from '../infra/adaptateurEmailBrevo';
+import { adaptateurRechercheEntreprise } from '../infra/adaptateurRechercheEntreprise';
+import { Utilisateur } from '../metier/utilisateur';
 
 export class ConsoleAdministration {
   private entrepotUtilisateur: EntrepotUtilisateur;

--- a/back/tests/api/ressourceFavori.spec.ts
+++ b/back/tests/api/ressourceFavori.spec.ts
@@ -5,6 +5,7 @@ import { creeServeur } from '../../src/api/msc';
 import {
   configurationDeTestDuServeur,
   fauxAdaptateurJWT,
+  fauxFournisseurDeChemin,
   fauxMiddleware,
 } from './fauxObjets';
 import assert from 'node:assert';
@@ -25,7 +26,10 @@ describe('La ressource des services et ressources favoris', () => {
     });
     serveur = creeServeur({
       ...configurationDeTestDuServeur,
-      middleware: fabriqueMiddleware({ adaptateurJWT: fauxAdaptateurJWT }),
+      middleware: fabriqueMiddleware({
+        adaptateurJWT: fauxAdaptateurJWT,
+        fournisseurChemin: fauxFournisseurDeChemin,
+      }),
       entrepotFavori,
     });
   });

--- a/back/tests/api/ressourceFavoris.spec.ts
+++ b/back/tests/api/ressourceFavoris.spec.ts
@@ -5,6 +5,7 @@ import { creeServeur } from '../../src/api/msc';
 import {
   configurationDeTestDuServeur,
   fauxAdaptateurJWT,
+  fauxFournisseurDeChemin,
   fauxMiddleware,
 } from './fauxObjets';
 import assert from 'node:assert';
@@ -25,7 +26,10 @@ describe('La ressource des services et ressources favoris', () => {
     });
     serveur = creeServeur({
       ...configurationDeTestDuServeur,
-      middleware: fabriqueMiddleware({ adaptateurJWT: fauxAdaptateurJWT }),
+      middleware: fabriqueMiddleware({
+        adaptateurJWT: fauxAdaptateurJWT,
+        fournisseurChemin: fauxFournisseurDeChemin,
+      }),
       entrepotFavori,
     });
   });

--- a/back/tests/persistance/entrepotUtilisateurMemoire.ts
+++ b/back/tests/persistance/entrepotUtilisateurMemoire.ts
@@ -4,6 +4,9 @@ import { randomUUID } from 'node:crypto';
 
 export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
   entites: Utilisateur[] = [];
+
+  tous = async () => [...this.entites];
+
   ajoute = async (utilisateur: UtilisateurPartiel) => {
     const {
       nom,


### PR DESCRIPTION
Dans un sous-répertoire des sources pour que celle-ci soit compilée dans dist-back et accessible dans l’environnement de production