### PR TITLE
[SOIN] Mutualise et corrige les entrepôts

### DIFF
--- a/back/src/admin/consoleAdministration.ts
+++ b/back/src/admin/consoleAdministration.ts
@@ -5,7 +5,7 @@ import { fabriqueAdaptateurProfilAnssi } from '../infra/adaptateurProfilAnssi';
 import { EntrepotUtilisateurMPAPostgres } from '../infra/entrepotUtilisateurMPAPostgres';
 import { fabriqueAdaptateurEmail } from '../infra/adaptateurEmailBrevo';
 import { adaptateurRechercheEntreprise } from '../infra/adaptateurRechercheEntreprise';
-import { ClasseUtilisateur } from '../metier/utilisateur';
+import { Utilisateur } from '../metier/utilisateur';
 
 export class ConsoleAdministration {
   private entrepotUtilisateur: EntrepotUtilisateur;
@@ -48,9 +48,9 @@ export class ConsoleAdministration {
 
   async rattrapageProfilsContactBrevo() {
     const tousUtilisateurs = await this.entrepotUtilisateur.tous();
-    const afficheErreur = (utilisateur: ClasseUtilisateur) =>
+    const afficheErreur = (utilisateur: Utilisateur) =>
       `Erreur pour ${utilisateur.email}`;
-    const rattrapeUtilisateur = async (utilisateur: ClasseUtilisateur) => {
+    const rattrapeUtilisateur = async (utilisateur: Utilisateur) => {
       const { prenom, nom, email, infolettreAcceptee } = utilisateur;
       this.adaptateurEmail.creeContactBrevo({
         prenom,

--- a/back/src/admin/consoleAdministration.ts
+++ b/back/src/admin/consoleAdministration.ts
@@ -5,7 +5,7 @@ import { fabriqueAdaptateurProfilAnssi } from '../infra/adaptateurProfilAnssi';
 import { EntrepotUtilisateurMPAPostgres } from '../infra/entrepotUtilisateurMPAPostgres';
 import { fabriqueAdaptateurEmail } from '../infra/adaptateurEmailBrevo';
 import { adaptateurRechercheEntreprise } from '../infra/adaptateurRechercheEntreprise';
-import { Utilisateur } from '../metier/utilisateur';
+import { ClasseUtilisateur } from '../metier/utilisateur';
 
 export class ConsoleAdministration {
   private entrepotUtilisateur: EntrepotUtilisateur;
@@ -48,9 +48,9 @@ export class ConsoleAdministration {
 
   async rattrapageProfilsContactBrevo() {
     const tousUtilisateurs = await this.entrepotUtilisateur.tous();
-    const afficheErreur = (utilisateur: Utilisateur) =>
+    const afficheErreur = (utilisateur: ClasseUtilisateur) =>
       `Erreur pour ${utilisateur.email}`;
-    const rattrapeUtilisateur = async (utilisateur: Utilisateur) => {
+    const rattrapeUtilisateur = async (utilisateur: ClasseUtilisateur) => {
       const { prenom, nom, email, infolettreAcceptee } = utilisateur;
       this.adaptateurEmail.creeContactBrevo({
         prenom,

--- a/back/src/api/ressourceContacts.ts
+++ b/back/src/api/ressourceContacts.ts
@@ -25,7 +25,7 @@ const ressourceContacts = ({
       }
 
       const codeRegion = regionDuDepartement(
-        utilisateur.organisation.departement as CodeDepartement
+        (await utilisateur.organisation()).departement as CodeDepartement
       );
 
       reponse.json(contactsParRegion[codeRegion]);

--- a/back/src/api/ressourceProfil.ts
+++ b/back/src/api/ressourceProfil.ts
@@ -20,7 +20,7 @@ const ressourceProfil = ({
         email,
         nom: utilisateurConnecte?.nom,
         prenom: utilisateurConnecte?.prenom,
-        siret: utilisateurConnecte?.organisation.siret,
+        siret: (await utilisateurConnecte?.organisation())?.siret,
         idListeFavoris: utilisateurConnecte?.idListeFavoris,
       });
     }

--- a/back/src/api/ressourceUtilisateurs.ts
+++ b/back/src/api/ressourceUtilisateurs.ts
@@ -2,11 +2,13 @@ import { Request, Response, Router } from 'express';
 import { ConfigurationServeur } from './configurationServeur';
 import { check } from 'express-validator';
 import { CompteCree } from '../bus/compteCree';
+import { ClasseUtilisateur } from '../metier/utilisateur';
 
 const ressourceUtilisateurs = ({
   busEvenements,
   entrepotUtilisateur,
   middleware,
+  adaptateurRechercheEntreprise
 }: ConfigurationServeur) => {
   const routeur = Router();
   routeur.post(
@@ -53,7 +55,7 @@ const ressourceUtilisateurs = ({
         infolettreAcceptee,
       } = requete.body;
 
-      await entrepotUtilisateur.ajoute({
+      const utilisateur = new ClasseUtilisateur({
         email,
         prenom,
         nom,
@@ -62,7 +64,9 @@ const ressourceUtilisateurs = ({
         siretEntite,
         cguAcceptees,
         infolettreAcceptee,
-      });
+      }, adaptateurRechercheEntreprise)
+
+      await entrepotUtilisateur.ajoute(utilisateur);
 
       await busEvenements.publie(
         new CompteCree({ email, prenom, nom, infoLettre: infolettreAcceptee })

--- a/back/src/api/ressourceUtilisateurs.ts
+++ b/back/src/api/ressourceUtilisateurs.ts
@@ -2,7 +2,7 @@ import { Request, Response, Router } from 'express';
 import { ConfigurationServeur } from './configurationServeur';
 import { check } from 'express-validator';
 import { CompteCree } from '../bus/compteCree';
-import { ClasseUtilisateur } from '../metier/utilisateur';
+import { Utilisateur } from '../metier/utilisateur';
 
 const ressourceUtilisateurs = ({
   busEvenements,
@@ -55,7 +55,7 @@ const ressourceUtilisateurs = ({
         infolettreAcceptee,
       } = requete.body;
 
-      const utilisateur = new ClasseUtilisateur({
+      const utilisateur = new Utilisateur({
         email,
         prenom,
         nom,

--- a/back/src/infra/entrepotUtilisateurMPAPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurMPAPostgres.ts
@@ -1,6 +1,6 @@
 import Knex from 'knex';
 import { EntrepotUtilisateur } from '../metier/entrepotUtilisateur';
-import { ClasseUtilisateur, Utilisateur } from '../metier/utilisateur';
+import { ClasseUtilisateur } from '../metier/utilisateur';
 import config from '../../knexfile';
 import { UtilisateurBDD } from './utilisateurBDD';
 import { AdaptateurProfilAnssi } from './adaptateurProfilAnssi';
@@ -83,7 +83,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
 
   async parIdListeFavoris(
     idListeFavoris: string
-  ): Promise<Utilisateur | undefined> {
+  ): Promise<ClasseUtilisateur | undefined> {
     const utilisateur = await this.knex('utilisateurs')
       .where({ id_liste_favoris: idListeFavoris })
       .first();
@@ -92,15 +92,21 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
     const donnees = this.dechiffreDonneesUtilisateur(utilisateur);
     const { prenom, nom, telephone, domainesSpecialite, organisation } =
       (await this.adaptateurProfilAnssi.recupere(donnees.email))!;
-    return {
-      ...donnees,
-      idListeFavoris: utilisateur.id_liste_favoris,
-      prenom,
-      nom,
-      telephone,
-      domainesSpecialite,
-      organisation,
-    };
+
+    return new ClasseUtilisateur(
+      {
+        email: donnees.email,
+        prenom,
+        nom,
+        telephone,
+        domainesSpecialite,
+        cguAcceptees: donnees.cguAcceptees,
+        infolettreAcceptee: donnees.infolettreAcceptee,
+        siretEntite: organisation.siret,
+        idListeFavoris: utilisateur.id_liste_favoris,
+      },
+      this.adaptateurRechercheEntreprise
+    );
   }
 
   async existe(email: string) {

--- a/back/src/infra/entrepotUtilisateurMPAPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurMPAPostgres.ts
@@ -124,16 +124,22 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
         const donnees = this.dechiffreDonneesUtilisateur(utilisateur);
         const { prenom, nom, telephone, domainesSpecialite, organisation } =
           (await this.adaptateurProfilAnssi.recupere(donnees.email))!;
-        return {
-          ...donnees,
-          idListeFavoris: utilisateur.id_liste_favoris,
-          email: donnees.email,
-          prenom,
-          nom,
-          telephone,
-          domainesSpecialite,
-          organisation,
-        };
+
+        return new ClasseUtilisateur(
+          {
+            email: donnees.email,
+            prenom,
+            nom,
+            telephone,
+            domainesSpecialite,
+            cguAcceptees: donnees.cguAcceptees,
+            infolettreAcceptee: donnees.infolettreAcceptee,
+            siretEntite: organisation.siret,
+            idListeFavoris: utilisateur.id_liste_favoris,
+          },
+          this.adaptateurRechercheEntreprise
+        );
+
       })
     );
   }

--- a/back/src/infra/entrepotUtilisateurMPAPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurMPAPostgres.ts
@@ -1,6 +1,6 @@
 import Knex from 'knex';
 import { EntrepotUtilisateur } from '../metier/entrepotUtilisateur';
-import { ClasseUtilisateur } from '../metier/utilisateur';
+import { Utilisateur } from '../metier/utilisateur';
 import config from '../../knexfile';
 import { UtilisateurBDD } from './utilisateurBDD';
 import { AdaptateurProfilAnssi } from './adaptateurProfilAnssi';
@@ -21,7 +21,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
   }
 
   private chiffreDonneesUtilisateur(
-    utilisateur: ClasseUtilisateur
+    utilisateur: Utilisateur
   ): UtilisateurBDD {
     return { email: utilisateur.email, donnees: utilisateur };
   }
@@ -36,7 +36,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
     };
   }
 
-  async ajoute(utilisateur: ClasseUtilisateur) {
+  async ajoute(utilisateur: Utilisateur) {
     // Enregistrement dans la BDD
     await this.knex('utilisateurs').insert(
       this.chiffreDonneesUtilisateur(utilisateur)
@@ -55,7 +55,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
     });
   }
 
-  async parEmail(email: string): Promise<ClasseUtilisateur | undefined> {
+  async parEmail(email: string): Promise<Utilisateur | undefined> {
     const utilisateur = await this.knex('utilisateurs')
       .where({ email })
       .first();
@@ -65,7 +65,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
     const { prenom, nom, telephone, domainesSpecialite, organisation } =
       (await this.adaptateurProfilAnssi.recupere(donnees.email))!;
 
-    return new ClasseUtilisateur(
+    return new Utilisateur(
       {
         email,
         prenom,
@@ -83,7 +83,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
 
   async parIdListeFavoris(
     idListeFavoris: string
-  ): Promise<ClasseUtilisateur | undefined> {
+  ): Promise<Utilisateur | undefined> {
     const utilisateur = await this.knex('utilisateurs')
       .where({ id_liste_favoris: idListeFavoris })
       .first();
@@ -93,7 +93,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
     const { prenom, nom, telephone, domainesSpecialite, organisation } =
       (await this.adaptateurProfilAnssi.recupere(donnees.email))!;
 
-    return new ClasseUtilisateur(
+    return new Utilisateur(
       {
         email: donnees.email,
         prenom,
@@ -125,7 +125,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
         const { prenom, nom, telephone, domainesSpecialite, organisation } =
           (await this.adaptateurProfilAnssi.recupere(donnees.email))!;
 
-        return new ClasseUtilisateur(
+        return new Utilisateur(
           {
             email: donnees.email,
             prenom,

--- a/back/src/infra/entrepotUtilisateurMPAPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurMPAPostgres.ts
@@ -1,6 +1,6 @@
 import Knex from 'knex';
 import { EntrepotUtilisateur } from '../metier/entrepotUtilisateur';
-import { ClasseUtilisateur, Utilisateur, UtilisateurPartiel } from '../metier/utilisateur';
+import { ClasseUtilisateur, Utilisateur } from '../metier/utilisateur';
 import config from '../../knexfile';
 import { UtilisateurBDD } from './utilisateurBDD';
 import { AdaptateurProfilAnssi } from './adaptateurProfilAnssi';
@@ -21,7 +21,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
   }
 
   private chiffreDonneesUtilisateur(
-    utilisateur: UtilisateurPartiel
+    utilisateur: ClasseUtilisateur
   ): UtilisateurBDD {
     return { email: utilisateur.email, donnees: utilisateur };
   }
@@ -44,8 +44,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
 
     // Enregistrement dans MPA
     const organisation = await utilisateur.organisation();
-    const { prenom, nom, telephone, email, domainesSpecialite } =
-      utilisateur;
+    const { prenom, nom, telephone, email, domainesSpecialite } = utilisateur;
     await this.adaptateurProfilAnssi.metsAJour({
       prenom,
       nom,

--- a/back/src/infra/entrepotUtilisateurMPAPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurMPAPostgres.ts
@@ -55,7 +55,7 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
     });
   }
 
-  async parEmail(email: string): Promise<Utilisateur | undefined> {
+  async parEmail(email: string): Promise<ClasseUtilisateur | undefined> {
     const utilisateur = await this.knex('utilisateurs')
       .where({ email })
       .first();
@@ -64,16 +64,21 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
     const donnees = this.dechiffreDonneesUtilisateur(utilisateur);
     const { prenom, nom, telephone, domainesSpecialite, organisation } =
       (await this.adaptateurProfilAnssi.recupere(donnees.email))!;
-    return {
-      ...donnees,
-      idListeFavoris: utilisateur.id_liste_favoris,
-      email,
-      prenom,
-      nom,
-      telephone,
-      domainesSpecialite,
-      organisation,
-    };
+
+    return new ClasseUtilisateur(
+      {
+        email,
+        prenom,
+        nom,
+        telephone,
+        domainesSpecialite,
+        cguAcceptees: donnees.cguAcceptees,
+        infolettreAcceptee: donnees.infolettreAcceptee,
+        siretEntite: organisation.siret,
+        idListeFavoris: utilisateur.id_liste_favoris,
+      },
+      this.adaptateurRechercheEntreprise
+    );
   }
 
   async parIdListeFavoris(

--- a/back/src/infra/entrepotUtilisateurMPAPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurMPAPostgres.ts
@@ -1,6 +1,6 @@
 import Knex from 'knex';
 import { EntrepotUtilisateur } from '../metier/entrepotUtilisateur';
-import { Utilisateur, UtilisateurPartiel } from '../metier/utilisateur';
+import { ClasseUtilisateur, Utilisateur, UtilisateurPartiel } from '../metier/utilisateur';
 import config from '../../knexfile';
 import { UtilisateurBDD } from './utilisateurBDD';
 import { AdaptateurProfilAnssi } from './adaptateurProfilAnssi';
@@ -36,24 +36,23 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
     };
   }
 
-  async ajoute(utilisateur: UtilisateurPartiel) {
-    const { prenom, nom, telephone, email, domainesSpecialite, siretEntite } =
-      utilisateur;
+  async ajoute(utilisateur: ClasseUtilisateur) {
+    // Enregistrement dans la BDD
     await this.knex('utilisateurs').insert(
       this.chiffreDonneesUtilisateur(utilisateur)
     );
-    const organisations =
-      await this.adaptateurRechercheEntreprise.rechercheOrganisations(
-        siretEntite,
-        null
-      );
+
+    // Enregistrement dans MPA
+    const organisation = await utilisateur.organisation();
+    const { prenom, nom, telephone, email, domainesSpecialite } =
+      utilisateur;
     await this.adaptateurProfilAnssi.metsAJour({
       prenom,
       nom,
       telephone,
       email,
       domainesSpecialite,
-      organisation: organisations[0],
+      organisation,
     });
   }
 

--- a/back/src/metier/entrepotUtilisateur.ts
+++ b/back/src/metier/entrepotUtilisateur.ts
@@ -1,7 +1,7 @@
-import { Utilisateur, UtilisateurPartiel } from './utilisateur';
+import { ClasseUtilisateur, Utilisateur } from './utilisateur';
 
 export interface EntrepotUtilisateur {
-  ajoute: (utilisateur: UtilisateurPartiel) => Promise<void>;
+  ajoute: (utilisateur: ClasseUtilisateur) => Promise<void>;
   parEmail: (email: string) => Promise<Utilisateur | undefined>;
   existe: (email: string) => Promise<boolean>;
   parIdListeFavoris: (

--- a/back/src/metier/entrepotUtilisateur.ts
+++ b/back/src/metier/entrepotUtilisateur.ts
@@ -6,6 +6,6 @@ export interface EntrepotUtilisateur {
   existe: (email: string) => Promise<boolean>;
   parIdListeFavoris: (
     idListeFavoris: string
-  ) => Promise<Utilisateur | undefined>;
+  ) => Promise<ClasseUtilisateur | undefined>;
   tous: () => Promise<Utilisateur[]>;
 }

--- a/back/src/metier/entrepotUtilisateur.ts
+++ b/back/src/metier/entrepotUtilisateur.ts
@@ -1,4 +1,4 @@
-import { ClasseUtilisateur, Utilisateur } from './utilisateur';
+import { ClasseUtilisateur } from './utilisateur';
 
 export interface EntrepotUtilisateur {
   ajoute: (utilisateur: ClasseUtilisateur) => Promise<void>;
@@ -7,5 +7,5 @@ export interface EntrepotUtilisateur {
   parIdListeFavoris: (
     idListeFavoris: string
   ) => Promise<ClasseUtilisateur | undefined>;
-  tous: () => Promise<Utilisateur[]>;
+  tous: () => Promise<ClasseUtilisateur[]>;
 }

--- a/back/src/metier/entrepotUtilisateur.ts
+++ b/back/src/metier/entrepotUtilisateur.ts
@@ -1,11 +1,11 @@
-import { ClasseUtilisateur } from './utilisateur';
+import { Utilisateur } from './utilisateur';
 
 export interface EntrepotUtilisateur {
-  ajoute: (utilisateur: ClasseUtilisateur) => Promise<void>;
-  parEmail: (email: string) => Promise<ClasseUtilisateur | undefined>;
+  ajoute: (utilisateur: Utilisateur) => Promise<void>;
+  parEmail: (email: string) => Promise<Utilisateur | undefined>;
   existe: (email: string) => Promise<boolean>;
   parIdListeFavoris: (
     idListeFavoris: string
-  ) => Promise<ClasseUtilisateur | undefined>;
-  tous: () => Promise<ClasseUtilisateur[]>;
+  ) => Promise<Utilisateur | undefined>;
+  tous: () => Promise<Utilisateur[]>;
 }

--- a/back/src/metier/entrepotUtilisateur.ts
+++ b/back/src/metier/entrepotUtilisateur.ts
@@ -2,7 +2,7 @@ import { ClasseUtilisateur, Utilisateur } from './utilisateur';
 
 export interface EntrepotUtilisateur {
   ajoute: (utilisateur: ClasseUtilisateur) => Promise<void>;
-  parEmail: (email: string) => Promise<Utilisateur | undefined>;
+  parEmail: (email: string) => Promise<ClasseUtilisateur | undefined>;
   existe: (email: string) => Promise<boolean>;
   parIdListeFavoris: (
     idListeFavoris: string

--- a/back/src/metier/utilisateur.ts
+++ b/back/src/metier/utilisateur.ts
@@ -18,7 +18,7 @@ interface InformationsCreationUtilisateur {
   idListeFavoris?: string;
 }
 
-export class ClasseUtilisateur {
+export class Utilisateur {
   email: string;
   prenom: string;
   nom: string;

--- a/back/src/metier/utilisateur.ts
+++ b/back/src/metier/utilisateur.ts
@@ -27,6 +27,7 @@ interface InformationsCreationUtilisateur {
   siretEntite: string;
   cguAcceptees: boolean;
   infolettreAcceptee: boolean;
+  idListeFavoris?: string;
 }
 
 export class ClasseUtilisateur {
@@ -38,7 +39,7 @@ export class ClasseUtilisateur {
   cguAcceptees: boolean;
   infolettreAcceptee: boolean;
   siretEntite: string;
-  idListeFavoris!: string;
+  idListeFavoris: string;
   private adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise;
 
   constructor(
@@ -51,6 +52,7 @@ export class ClasseUtilisateur {
       cguAcceptees,
       infolettreAcceptee,
       siretEntite,
+      idListeFavoris,
     }: InformationsCreationUtilisateur,
     adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise
   ) {
@@ -63,7 +65,7 @@ export class ClasseUtilisateur {
     this.infolettreAcceptee = infolettreAcceptee;
     this.siretEntite = siretEntite;
     this.adaptateurRechercheEntreprise = adaptateurRechercheEntreprise;
-    // this.idListeFavoris = idListeFavoris;
+    this.idListeFavoris = idListeFavoris ?? '';
   }
 
   async organisation(): Promise<Organisation> {

--- a/back/src/metier/utilisateur.ts
+++ b/back/src/metier/utilisateur.ts
@@ -1,3 +1,5 @@
+import { AdaptateurRechercheEntreprise } from '../infra/adaptateurRechercheEntreprise';
+
 type Organisation = {
   nom: string;
   siret: string;
@@ -25,4 +27,51 @@ export interface UtilisateurPartiel {
   siretEntite: string;
   cguAcceptees: boolean;
   infolettreAcceptee: boolean;
+}
+
+export class ClasseUtilisateur implements UtilisateurPartiel{
+  email: string;
+  prenom: string;
+  nom: string;
+  telephone?: string;
+  domainesSpecialite: string[];
+  cguAcceptees: boolean;
+  infolettreAcceptee: boolean;
+  siretEntite: string;
+  idListeFavoris!: string;
+  private adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise;
+
+  constructor(
+    {
+      email,
+      prenom,
+      nom,
+      telephone,
+      domainesSpecialite,
+      cguAcceptees,
+      infolettreAcceptee,
+      siretEntite,
+    }: UtilisateurPartiel,
+    adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise
+  ) {
+    this.email = email;
+    this.prenom = prenom;
+    this.nom = nom;
+    this.telephone = telephone;
+    this.domainesSpecialite = domainesSpecialite;
+    this.cguAcceptees = cguAcceptees;
+    this.infolettreAcceptee = infolettreAcceptee;
+    this.siretEntite = siretEntite;
+    this.adaptateurRechercheEntreprise = adaptateurRechercheEntreprise;
+    // this.idListeFavoris = idListeFavoris;
+  }
+
+  async organisation(): Promise<Organisation> {
+    const organisations =
+      await this.adaptateurRechercheEntreprise.rechercheOrganisations(
+        this.siretEntite,
+        null
+      );
+    return organisations[0];
+  }
 }

--- a/back/src/metier/utilisateur.ts
+++ b/back/src/metier/utilisateur.ts
@@ -18,7 +18,7 @@ export interface Utilisateur {
   idListeFavoris: string;
 }
 
-export interface UtilisateurPartiel {
+interface InformationsCreationUtilisateur {
   email: string;
   prenom: string;
   nom: string;
@@ -29,7 +29,7 @@ export interface UtilisateurPartiel {
   infolettreAcceptee: boolean;
 }
 
-export class ClasseUtilisateur implements UtilisateurPartiel{
+export class ClasseUtilisateur {
   email: string;
   prenom: string;
   nom: string;
@@ -51,7 +51,7 @@ export class ClasseUtilisateur implements UtilisateurPartiel{
       cguAcceptees,
       infolettreAcceptee,
       siretEntite,
-    }: UtilisateurPartiel,
+    }: InformationsCreationUtilisateur,
     adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise
   ) {
     this.email = email;

--- a/back/src/metier/utilisateur.ts
+++ b/back/src/metier/utilisateur.ts
@@ -6,18 +6,6 @@ type Organisation = {
   departement: string | null;
 };
 
-export interface Utilisateur {
-  email: string;
-  prenom: string;
-  nom: string;
-  telephone?: string;
-  domainesSpecialite: string[];
-  organisation: Organisation;
-  cguAcceptees: boolean;
-  infolettreAcceptee: boolean;
-  idListeFavoris: string;
-}
-
 interface InformationsCreationUtilisateur {
   email: string;
   prenom: string;

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -43,7 +43,9 @@ export const fauxAdaptateurJWT: AdaptateurJWT = {
 
 export const fauxAdaptateurRechercheEntreprise: AdaptateurRechercheEntreprise =
   {
-    rechercheOrganisations: async (_: string, __: string | null) => [],
+    rechercheOrganisations: async (siret: string, __: string | null) => [
+      { siret, nom: '', departement: '' },
+    ],
   };
 
 export const fauxAdaptateurProfilAnssi: AdaptateurProfilAnssi = {

--- a/back/tests/api/objetsPretsALEmploi.ts
+++ b/back/tests/api/objetsPretsALEmploi.ts
@@ -1,7 +1,7 @@
-import { ClasseUtilisateur } from '../../src/metier/utilisateur';
+import { Utilisateur } from '../../src/metier/utilisateur';
 import { fauxAdaptateurRechercheEntreprise } from './fauxObjets';
 
-export const jeanneDupont: ClasseUtilisateur = new ClasseUtilisateur(
+export const jeanneDupont: Utilisateur = new Utilisateur(
   {
     email: 'jeanne.dupont@user.com',
     prenom: 'Jeanne',

--- a/back/tests/api/objetsPretsALEmploi.ts
+++ b/back/tests/api/objetsPretsALEmploi.ts
@@ -1,12 +1,16 @@
-import { UtilisateurPartiel } from '../../src/metier/utilisateur';
+import { ClasseUtilisateur } from '../../src/metier/utilisateur';
+import { fauxAdaptateurRechercheEntreprise } from './fauxObjets';
 
-export const jeanneDupont: UtilisateurPartiel = {
-  email: 'jeanne.dupont@user.com',
-  prenom: 'Jeanne',
-  nom: 'Dupont',
-  telephone: '0123456789',
-  domainesSpecialite: ['RSSI'],
-  siretEntite: '13000766900018',
-  cguAcceptees: true,
-  infolettreAcceptee: true,
-};
+export const jeanneDupont: ClasseUtilisateur = new ClasseUtilisateur(
+  {
+    email: 'jeanne.dupont@user.com',
+    prenom: 'Jeanne',
+    nom: 'Dupont',
+    telephone: '0123456789',
+    domainesSpecialite: ['RSSI'],
+    siretEntite: '13000766900018',
+    cguAcceptees: true,
+    infolettreAcceptee: true,
+  },
+  fauxAdaptateurRechercheEntreprise
+);

--- a/back/tests/api/oidc/ressourceApresAuthentificationOIDC.spec.ts
+++ b/back/tests/api/oidc/ressourceApresAuthentificationOIDC.spec.ts
@@ -16,7 +16,7 @@ import { AdaptateurOIDC } from '../../../src/api/oidc/adaptateurOIDC';
 import { decodeSessionDuCookie } from '../cookie';
 import { AdaptateurJWT } from '../../../src/api/adaptateurJWT';
 import { EntrepotUtilisateurMemoire } from '../../persistance/entrepotUtilisateurMemoire';
-import { ClasseUtilisateur } from '../../../src/metier/utilisateur';
+import { Utilisateur } from '../../../src/metier/utilisateur';
 
 describe('La ressource apres authentification OIDC', () => {
   describe('quand on fait un GET sur /oidc/apres-authentification', () => {
@@ -47,7 +47,7 @@ describe('La ressource apres authentification OIDC', () => {
 
     describe("si l'utilisateur est connu", () => {
       beforeEach(() => {
-        const jeanneDupont = new ClasseUtilisateur(
+        const jeanneDupont = new Utilisateur(
           {
             email: 'jeanne.dupont',
             cguAcceptees: true,

--- a/back/tests/api/oidc/ressourceApresAuthentificationOIDC.spec.ts
+++ b/back/tests/api/oidc/ressourceApresAuthentificationOIDC.spec.ts
@@ -8,6 +8,7 @@ import {
   configurationDeTestDuServeur,
   fauxAdaptateurJWT,
   fauxAdaptateurOIDC,
+  fauxAdaptateurRechercheEntreprise,
   fauxFournisseurDeChemin,
 } from '../fauxObjets';
 import { join } from 'node:path';
@@ -15,7 +16,7 @@ import { AdaptateurOIDC } from '../../../src/api/oidc/adaptateurOIDC';
 import { decodeSessionDuCookie } from '../cookie';
 import { AdaptateurJWT } from '../../../src/api/adaptateurJWT';
 import { EntrepotUtilisateurMemoire } from '../../persistance/entrepotUtilisateurMemoire';
-import { UtilisateurPartiel } from '../../../src/metier/utilisateur';
+import { ClasseUtilisateur } from '../../../src/metier/utilisateur';
 
 describe('La ressource apres authentification OIDC', () => {
   describe('quand on fait un GET sur /oidc/apres-authentification', () => {
@@ -46,15 +47,18 @@ describe('La ressource apres authentification OIDC', () => {
 
     describe("si l'utilisateur est connu", () => {
       beforeEach(() => {
-        const jeanneDupont: UtilisateurPartiel = {
-          email: 'jeanne.dupont',
-          cguAcceptees: true,
-          infolettreAcceptee: true,
-          prenom: '',
-          nom: '',
-          siretEntite: '',
-          domainesSpecialite: [],
-        };
+        const jeanneDupont = new ClasseUtilisateur(
+          {
+            email: 'jeanne.dupont',
+            cguAcceptees: true,
+            infolettreAcceptee: true,
+            prenom: '',
+            nom: '',
+            siretEntite: '',
+            domainesSpecialite: [],
+          },
+          fauxAdaptateurRechercheEntreprise
+        );
         entrepotUtilisateur.ajoute(jeanneDupont);
 
         adaptateurOIDC.recupereInformationsUtilisateur = async (_) => ({

--- a/back/tests/api/ressourceContacts.spec.ts
+++ b/back/tests/api/ressourceContacts.spec.ts
@@ -7,7 +7,7 @@ import request from 'supertest';
 import { EntrepotUtilisateur } from '../../src/metier/entrepotUtilisateur';
 import { EntrepotUtilisateurMemoire } from '../persistance/entrepotUtilisateurMemoire';
 import { randomUUID } from 'node:crypto';
-import { ClasseUtilisateur } from '../../src/metier/utilisateur';
+import { Utilisateur } from '../../src/metier/utilisateur';
 import { AdaptateurRechercheEntreprise } from '../../src/infra/adaptateurRechercheEntreprise';
 
 describe('La ressource Contacts', () => {
@@ -68,7 +68,7 @@ describe('La ressource Contacts', () => {
         ],
       };
       entrepotUtilisateur.parEmail = async () =>
-        new ClasseUtilisateur(
+        new Utilisateur(
           {
             email: 'jeanne.dupont@user.com',
             prenom: 'Jeanne',

--- a/back/tests/api/ressourceUtilisateurs.spec.ts
+++ b/back/tests/api/ressourceUtilisateurs.spec.ts
@@ -10,10 +10,12 @@ import {
   MockBusEvenement,
 } from '../bus/busPourLesTests';
 import { CompteCree } from '../../src/bus/compteCree';
+import { AdaptateurRechercheEntreprise } from '../../src/infra/adaptateurRechercheEntreprise';
 
 describe('La ressource utilisateur', () => {
   let serveur: Express;
   let entrepotUtilisateur: EntrepotUtilisateurMemoire;
+  let adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise;
   const donneesUtilisateur = {
     email: 'jeanne.dupont@user.com',
     prenom: 'Jeanne',
@@ -29,11 +31,15 @@ describe('La ressource utilisateur', () => {
   beforeEach(() => {
     entrepotUtilisateur = new EntrepotUtilisateurMemoire();
     busEvenements = fabriqueBusPourLesTests();
+    adaptateurRechercheEntreprise = {
+      rechercheOrganisations: async (_: string, __: string | null) => [],
+    };
 
     serveur = creeServeur({
       ...configurationDeTestDuServeur,
       entrepotUtilisateur,
       busEvenements,
+      adaptateurRechercheEntreprise,
     });
   });
 
@@ -47,6 +53,14 @@ describe('La ressource utilisateur', () => {
     });
 
     it("ajoute un utilisateur à l'entrepot", async () => {
+      adaptateurRechercheEntreprise.rechercheOrganisations = async () => [
+        {
+          nom: '',
+          departement: '',
+          siret: '13000766900018',
+        },
+      ];
+
       await request(serveur).post('/api/utilisateurs').send(donneesUtilisateur);
 
       const jeanne = await entrepotUtilisateur.parEmail(
@@ -75,6 +89,14 @@ describe('La ressource utilisateur', () => {
     });
 
     it('aseptise les paramètres', async () => {
+      adaptateurRechercheEntreprise.rechercheOrganisations = async () => [
+        {
+          nom: '',
+          departement: '',
+          siret: '13000766900018',
+        },
+      ];
+
       await request(serveur)
         .post('/api/utilisateurs')
         .send({

--- a/back/tests/api/ressourceUtilisateurs.spec.ts
+++ b/back/tests/api/ressourceUtilisateurs.spec.ts
@@ -72,7 +72,7 @@ describe('La ressource utilisateur', () => {
       assert.equal(jeanne?.nom, 'Dupont');
       assert.equal(jeanne?.telephone, '0123456789');
       assert.deepEqual(jeanne?.domainesSpecialite, ['RSSI']);
-      assert.equal(jeanne?.organisation.siret, '13000766900018');
+      assert.equal((await jeanne?.organisation())?.siret, '13000766900018');
       assert.equal(jeanne?.cguAcceptees, true);
       assert.equal(jeanne?.infolettreAcceptee, true);
     });
@@ -119,7 +119,7 @@ describe('La ressource utilisateur', () => {
       assert.equal(jeanne?.nom, '&lt;Dupont');
       assert.equal(jeanne?.telephone, '0123456789');
       assert.deepEqual(jeanne?.domainesSpecialite, ['RSSI']);
-      assert.equal(jeanne?.organisation.siret, '13000766900018');
+      assert.equal((await jeanne?.organisation())?.siret, '13000766900018');
     });
 
     describe('concernant la validation des données', () => {

--- a/back/tests/persistance/entrepotFavoriMemoire.ts
+++ b/back/tests/persistance/entrepotFavoriMemoire.ts
@@ -1,12 +1,8 @@
 import { EntrepotFavori } from '../../src/metier/entrepotFavori';
 import { Favori } from '../../src/metier/favori';
+import { EntrepotMemoire } from './entrepotMemoire';
 
-export class EntrepotFavoriMemoire implements EntrepotFavori {
-  entites: Favori[] = [];
-
-  async ajoute(favori: Favori): Promise<void> {
-    this.entites.push(favori);
-  }
+export class EntrepotFavoriMemoire extends EntrepotMemoire<Favori> implements EntrepotFavori {
 
   async retire(favori: Favori): Promise<void> {
     this.entites = this.entites.filter(

--- a/back/tests/persistance/entrepotMemoire.ts
+++ b/back/tests/persistance/entrepotMemoire.ts
@@ -1,0 +1,7 @@
+export class EntrepotMemoire<T>  {
+  entites:T[] = [];
+  
+  ajoute = async (entite: T) => {
+    this.entites.push(entite);
+  };
+}

--- a/back/tests/persistance/entrepotResultatTestMemoire.ts
+++ b/back/tests/persistance/entrepotResultatTestMemoire.ts
@@ -1,12 +1,8 @@
 import { EntrepotResultatTest } from '../../src/metier/entrepotResultatTest';
 import { ResultatTestMaturite } from '../../src/metier/resultatTestMaturite';
+import { EntrepotMemoire } from './entrepotMemoire';
 
-export class EntrepotResultatTestMemoire implements EntrepotResultatTest {
-  entites: ResultatTestMaturite[] = [];
-
-  async ajoute(resultatTest: ResultatTestMaturite): Promise<void> {
-    this.entites.push(resultatTest);
-  }
+export class EntrepotResultatTestMemoire extends EntrepotMemoire<ResultatTestMaturite> implements EntrepotResultatTest {
 
   async metsAjour(resultatTest: ResultatTestMaturite): Promise<void> {
     const entiteAMettreAJour = this.entites.find(

--- a/back/tests/persistance/entrepotUtilisateurMemoire.ts
+++ b/back/tests/persistance/entrepotUtilisateurMemoire.ts
@@ -1,38 +1,14 @@
 import { EntrepotUtilisateur } from '../../src/metier/entrepotUtilisateur';
-import { ClasseUtilisateur, Utilisateur } from '../../src/metier/utilisateur';
+import { ClasseUtilisateur } from '../../src/metier/utilisateur';
 import { randomUUID } from 'node:crypto';
 
 export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
-  entites: Utilisateur[] = [];
   utilisateurs: ClasseUtilisateur[] = [];
 
   tous = async () => [...this.utilisateurs];
 
   ajoute = async (utilisateur: ClasseUtilisateur) => {
-    const {
-      nom,
-      prenom,
-      email,
-      telephone,
-      domainesSpecialite,
-      cguAcceptees,
-      infolettreAcceptee,
-    } = utilisateur;
-
-    const idListeFavoris = randomUUID();
-    const utilisateurComplet = {
-      nom,
-      prenom,
-      email,
-      telephone,
-      domainesSpecialite,
-      cguAcceptees,
-      infolettreAcceptee,
-      idListeFavoris,
-      organisation: await utilisateur.organisation(),
-    };
-    utilisateur.idListeFavoris = idListeFavoris;
-    this.entites.push(utilisateurComplet);
+    utilisateur.idListeFavoris = randomUUID();
     this.utilisateurs.push(utilisateur);
   };
   parEmail = async (email: string) => {
@@ -44,6 +20,8 @@ export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
     );
   };
   existe = async (email: string) => {
-    return !!this.entites.find((utilisateur) => utilisateur.email === email);
+    return !!this.utilisateurs.find(
+      (utilisateur) => utilisateur.email === email
+    );
   };
 }

--- a/back/tests/persistance/entrepotUtilisateurMemoire.ts
+++ b/back/tests/persistance/entrepotUtilisateurMemoire.ts
@@ -1,13 +1,13 @@
 import { EntrepotUtilisateur } from '../../src/metier/entrepotUtilisateur';
-import { ClasseUtilisateur } from '../../src/metier/utilisateur';
+import { Utilisateur } from '../../src/metier/utilisateur';
 import { randomUUID } from 'node:crypto';
 
 export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
-  utilisateurs: ClasseUtilisateur[] = [];
+  utilisateurs: Utilisateur[] = [];
 
   tous = async () => [...this.utilisateurs];
 
-  ajoute = async (utilisateur: ClasseUtilisateur) => {
+  ajoute = async (utilisateur: Utilisateur) => {
     utilisateur.idListeFavoris = randomUUID();
     this.utilisateurs.push(utilisateur);
   };

--- a/back/tests/persistance/entrepotUtilisateurMemoire.ts
+++ b/back/tests/persistance/entrepotUtilisateurMemoire.ts
@@ -6,7 +6,7 @@ export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
   entites: Utilisateur[] = [];
   utilisateurs: ClasseUtilisateur[] = [];
 
-  tous = async () => [...this.entites];
+  tous = async () => [...this.utilisateurs];
 
   ajoute = async (utilisateur: ClasseUtilisateur) => {
     const {

--- a/back/tests/persistance/entrepotUtilisateurMemoire.ts
+++ b/back/tests/persistance/entrepotUtilisateurMemoire.ts
@@ -39,7 +39,7 @@ export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
     return this.utilisateurs.find((utilisateur) => utilisateur.email === email);
   };
   parIdListeFavoris = async (idListeFavoris: string) => {
-    return this.entites.find(
+    return this.utilisateurs.find(
       (utilisateur) => utilisateur.idListeFavoris === idListeFavoris
     );
   };

--- a/back/tests/persistance/entrepotUtilisateurMemoire.ts
+++ b/back/tests/persistance/entrepotUtilisateurMemoire.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto';
 
 export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
   entites: Utilisateur[] = [];
+  utilisateurs: ClasseUtilisateur[] = [];
 
   tous = async () => [...this.entites];
 
@@ -17,6 +18,8 @@ export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
       cguAcceptees,
       infolettreAcceptee,
     } = utilisateur;
+
+    const idListeFavoris = randomUUID();
     const utilisateurComplet = {
       nom,
       prenom,
@@ -25,14 +28,15 @@ export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
       domainesSpecialite,
       cguAcceptees,
       infolettreAcceptee,
-      idListeFavoris: randomUUID(),
+      idListeFavoris,
       organisation: await utilisateur.organisation(),
     };
+    utilisateur.idListeFavoris = idListeFavoris;
     this.entites.push(utilisateurComplet);
-    //this.entites.push(utilisateur);
+    this.utilisateurs.push(utilisateur);
   };
   parEmail = async (email: string) => {
-    return this.entites.find((utilisateur) => utilisateur.email === email);
+    return this.utilisateurs.find((utilisateur) => utilisateur.email === email);
   };
   parIdListeFavoris = async (idListeFavoris: string) => {
     return this.entites.find(

--- a/back/tests/persistance/entrepotUtilisateurMemoire.ts
+++ b/back/tests/persistance/entrepotUtilisateurMemoire.ts
@@ -1,5 +1,5 @@
 import { EntrepotUtilisateur } from '../../src/metier/entrepotUtilisateur';
-import { Utilisateur, UtilisateurPartiel } from '../../src/metier/utilisateur';
+import { ClasseUtilisateur, Utilisateur } from '../../src/metier/utilisateur';
 import { randomUUID } from 'node:crypto';
 
 export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
@@ -7,7 +7,7 @@ export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
 
   tous = async () => [...this.entites];
 
-  ajoute = async (utilisateur: UtilisateurPartiel) => {
+  ajoute = async (utilisateur: ClasseUtilisateur) => {
     const {
       nom,
       prenom,
@@ -16,7 +16,6 @@ export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
       domainesSpecialite,
       cguAcceptees,
       infolettreAcceptee,
-      siretEntite,
     } = utilisateur;
     const utilisateurComplet = {
       nom,
@@ -27,9 +26,10 @@ export class EntrepotUtilisateurMemoire implements EntrepotUtilisateur {
       cguAcceptees,
       infolettreAcceptee,
       idListeFavoris: randomUUID(),
-      organisation: { siret: siretEntite, departement: '75', nom: 'ANSSI' },
+      organisation: await utilisateur.organisation(),
     };
     this.entites.push(utilisateurComplet);
+    //this.entites.push(utilisateur);
   };
   parEmail = async (email: string) => {
     return this.entites.find((utilisateur) => utilisateur.email === email);


### PR DESCRIPTION
Le but est de mutualiser le comportement des entrepôts en mémoire et postgresql au maximum. 
De plus, on cherche à uniformiser l’interface de l’entrepôt des utilisateurs pour que celui-ci ne manipule plus qu’un seul type d’entité, à la fois pour l’ajout et pour les lectures. Pour cela, on ramène dans une classe utilisateur la responsabilité de lire l’organisation dans l’adaptateur de recherche entreprise. 