### PR TITLE
[CORRECTION] Corrige l'inscription qui été bloqué lors de la soumission du formulaire

### DIFF
--- a/back/src/infra/utilisateurBDD.ts
+++ b/back/src/infra/utilisateurBDD.ts
@@ -5,5 +5,5 @@ export interface UtilisateurBDD {
     cguAcceptees: boolean;
     infolettreAcceptee: boolean;
   };
-  id_liste_favoris: string;
+  id_liste_favoris: string | undefined;
 }

--- a/back/src/metier/utilisateur.ts
+++ b/back/src/metier/utilisateur.ts
@@ -28,7 +28,7 @@ export class Utilisateur {
   cguAcceptees: boolean;
   infolettreAcceptee: boolean;
   siretEntite: string;
-  idListeFavoris: string;
+  idListeFavoris: string | undefined;
   private adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise;
   private _organisation: Organisation | undefined;
 
@@ -56,7 +56,7 @@ export class Utilisateur {
     this.infolettreAcceptee = infolettreAcceptee;
     this.siretEntite = siretEntite;
     this.adaptateurRechercheEntreprise = adaptateurRechercheEntreprise;
-    this.idListeFavoris = idListeFavoris ?? '';
+    this.idListeFavoris = idListeFavoris ?? undefined;
     this._organisation = organisation;
   }
 


### PR DESCRIPTION


... L'id de la liste des favori était mis par défaut à `string vide` ce qui a causé une erreur lors de l'insertion en BDD Knex attends un champ au format UUID et cette valeur est interdite. Pour résoudre ce problème la valeur par défaut est mise à `undefined`.