### PR TITLE
[MonAideCyber] Prends en compte le nom d’usage ainsi que l’identifiant de l’utilisateur MAC

### DIFF
--- a/back/src/api/mon-aide-cyber/ressourceDemandesAide.ts
+++ b/back/src/api/mon-aide-cyber/ressourceDemandesAide.ts
@@ -11,6 +11,7 @@ export type CorpsDemandeAide = {
     raisonSociale: string;
   };
   emailAidant?: string;
+  identifiantAidant?: string;
   validationCGU: boolean;
 };
 
@@ -26,7 +27,8 @@ const ressourceDemandesAide = ({
       'entiteAidee.email',
       'entiteAidee.departement',
       'entiteAidee.raisonSociale',
-      'emailAidant'
+      'emailAidant',
+      'identifiantAidant'
     ),
     check('entiteAidee.departement')
       .isString()
@@ -44,16 +46,22 @@ const ressourceDemandesAide = ({
       .optional({ checkFalsy: true })
       .isEmail()
       .withMessage('Veuillez saisir un email valide pour l’Aidant.'),
+    body('identifiantAidant')
+      .optional({ values: 'falsy' })
+      .trim()
+      .isUUID()
+      .withMessage('Veuillez saisir un identifiant Aidant valide.'),
     body('validationCGU')
       .custom((validationCGU) => !!validationCGU)
       .withMessage('Veuillez valider les CGU.'),
     middleware.valide(),
     async (requete: CorpsDeRequeteTypee<CorpsDemandeAide>, reponse) => {
       try {
-        const { emailAidant, entiteAidee } = requete.body;
+        const { emailAidant, identifiantAidant, entiteAidee } = requete.body;
         const { email, departement, raisonSociale } = entiteAidee;
         await adaptateurMonAideCyber.creeDemandeAide({
           ...(emailAidant && { emailAidant }),
+          ...(identifiantAidant && { identifiantAidant }),
           entiteAidee: {
             email,
             departement,

--- a/back/src/infra/adaptateurMonAideCyber.ts
+++ b/back/src/infra/adaptateurMonAideCyber.ts
@@ -8,6 +8,7 @@ export type DemandeAide = {
     raisonSociale: string;
   };
   emailAidant?: string;
+  identifiantAidant?: string;
 };
 
 export interface AdaptateurMonAideCyber {
@@ -15,7 +16,7 @@ export interface AdaptateurMonAideCyber {
 }
 
 const adaptateurMonAideCyber = (): AdaptateurMonAideCyber => {
-  const creeDemandeAide = async ({ entiteAidee, emailAidant }: DemandeAide) => {
+  const creeDemandeAide = async ({ entiteAidee, emailAidant, identifiantAidant }: DemandeAide) => {
     try {
       const { email, raisonSociale, departement } = entiteAidee;
       const demandeMAC = {
@@ -24,6 +25,7 @@ const adaptateurMonAideCyber = (): AdaptateurMonAideCyber => {
         departement,
         raisonSociale,
         ...(emailAidant && { relationUtilisateur: emailAidant }),
+        ...(identifiantAidant && { identifiantAidant }),
       };
       await axios.post(
         `${process.env.MON_AIDE_CYBER_URL_BASE}/api/demandes/etre-aide`,

--- a/front/lib-svelte/src/demande-aide-mon-aide-cyber/DemandeAideMAC.svelte
+++ b/front/lib-svelte/src/demande-aide-mon-aide-cyber/DemandeAideMAC.svelte
@@ -24,7 +24,7 @@
     try {
       enCoursEnvoi = true;
 
-      const { email, cguSontValidees, emailAidant, entite } = e.detail;
+      const { email, cguSontValidees, emailUtilisateurMAC, entite, identifiantAidant } = e.detail;
       const corps: CorpsAPIDemandeAide = {
         entiteAidee: {
           email,
@@ -32,7 +32,8 @@
           raisonSociale: entite.nom,
         },
         validationCGU: cguSontValidees,
-        ...(emailAidant && { emailAidant }),
+        ...(emailUtilisateurMAC && { emailAidant: emailUtilisateurMAC }),
+        ...(identifiantAidant && {identifiantAidant})
       };
       const reponse = await axios.post(
         '/api/mon-aide-cyber/demandes-aide',

--- a/front/lib-svelte/src/demande-aide-mon-aide-cyber/DonneesFormulaireDemandeAide.ts
+++ b/front/lib-svelte/src/demande-aide-mon-aide-cyber/DonneesFormulaireDemandeAide.ts
@@ -2,7 +2,8 @@ import type { Organisation } from '../ui/formulaire/SelectionOrganisation.types'
 
 export type DonneesFormulaireDemandeAide = {
   email: string;
-  emailAidant?: string;
+  emailUtilisateurMAC?: string;
+  identifiantAidant?: string;
   entite: Organisation;
   cguSontValidees: boolean;
 };
@@ -14,5 +15,6 @@ export type CorpsAPIDemandeAide = {
     raisonSociale: string;
   };
   emailAidant?: string;
+  identifiantAidant?: string;
   validationCGU: boolean;
 };

--- a/front/lib-svelte/src/ui/Alerte.svelte
+++ b/front/lib-svelte/src/ui/Alerte.svelte
@@ -25,6 +25,7 @@
   .alerte {
     width: 100%;
     display: flex;
+    margin-top: 32px;
 
     .icone {
       display: flex;


### PR DESCRIPTION
En vue de pouvoir gérer les demandes émanant depuis l’annuaire Aidant depuis MonAideCyber