### PR TITLE
Ajoute une vérification typescript lors des tests back

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "serveur.ts",
   "scripts": {
-    "test": "npx eslint . && node --import tsx --test './tests/**/*.spec.ts'",
+    "test": "npx eslint . && tsc --noemit && node --import tsx --test './tests/**/*.spec.ts'",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint . --fix"
   },


### PR DESCRIPTION
Aujourd'hui c'est récurrent de se retrouver en PR avec des erreurs de types ou de compilation après un refactoring.
Ajouter ce script permet de vérifier la validité de la compilation à chaque fois que l'on lance les tests backend et fluidifiera et faciltera le processus de développement et de pull request. 