### PR TITLE
Ajuste l'affichage du bouton dans l'encart NIS2 sur l'accueil

### DIFF
--- a/front/assets/styles/site.scss
+++ b/front/assets/styles/site.scss
@@ -590,8 +590,11 @@ footer {
       a {
         grid-area: bouton;
         padding: 10px 24px;
+        margin: 16px auto;
+        justify-self: center;
+
         @include a-partir-de(lg) {
-          margin-top: 8px;
+          margin: 64px 0 0 0;
           justify-self: start;
         }
       }
@@ -724,8 +727,7 @@ select {
 }
 
 code {
-  background: rgba(0,0,0,.1);
+  background: rgba(0, 0, 0, 0.1);
   padding-left: 3px;
   padding-right: 3px;
 }
-


### PR DESCRIPTION
### Corrige: 
-  la taille du bouton en version bureau
-  centre le bouton en version mobile


### Avant : 
<img width="473" alt="image" src="https://github.com/user-attachments/assets/988a63a4-cd2c-49ed-87ad-a5b657650d18" />
<img width="1097" alt="image" src="https://github.com/user-attachments/assets/15d887d1-0751-4a6c-a0f9-65034d185f85" />

### Après :
<img width="519" alt="image" src="https://github.com/user-attachments/assets/6c8af5b2-e9c1-4176-b208-3b6343a2cc2a" />
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/d95ed1db-995d-44fc-9a7a-33b8ac5cf560" />

