### PR TITLE
[CYBERDEPART] Ajoute le SIRET lors de la demande d’Aide

### DIFF
--- a/back/src/api/mon-aide-cyber/ressourceDemandesAide.ts
+++ b/back/src/api/mon-aide-cyber/ressourceDemandesAide.ts
@@ -9,6 +9,7 @@ export type CorpsDemandeAide = {
     email: string;
     departement: string;
     raisonSociale: string;
+    siret: string;
   };
   emailAidant?: string;
   identifiantAidant?: string;
@@ -34,6 +35,9 @@ const ressourceDemandesAide = ({
       .isString()
       .isIn(codeDepartement)
       .withMessage('Veuillez saisir un département valide.'),
+    check('entiteAidee.siret')
+      .matches(/^\d{14}$/)
+      .withMessage('Veuillez saisir un SIRET valide.'),
     body('entiteAidee.raisonSociale')
       .isString()
       .notEmpty()
@@ -58,7 +62,7 @@ const ressourceDemandesAide = ({
     async (requete: CorpsDeRequeteTypee<CorpsDemandeAide>, reponse) => {
       try {
         const { emailAidant, identifiantAidant, entiteAidee } = requete.body;
-        const { email, departement, raisonSociale } = entiteAidee;
+        const { email, departement, raisonSociale, siret } = entiteAidee;
         await adaptateurMonAideCyber.creeDemandeAide({
           ...(emailAidant && { emailAidant }),
           ...(identifiantAidant && { identifiantAidant }),
@@ -66,6 +70,7 @@ const ressourceDemandesAide = ({
             email,
             departement,
             raisonSociale,
+            siret
           },
         });
         reponse.sendStatus(201);

--- a/back/src/infra/adaptateurMonAideCyber.ts
+++ b/back/src/infra/adaptateurMonAideCyber.ts
@@ -6,6 +6,7 @@ export type DemandeAide = {
     email: string;
     departement: string;
     raisonSociale: string;
+    siret: string;
   };
   emailAidant?: string;
   identifiantAidant?: string;
@@ -18,12 +19,13 @@ export interface AdaptateurMonAideCyber {
 const adaptateurMonAideCyber = (): AdaptateurMonAideCyber => {
   const creeDemandeAide = async ({ entiteAidee, emailAidant, identifiantAidant }: DemandeAide) => {
     try {
-      const { email, raisonSociale, departement } = entiteAidee;
+      const { email, raisonSociale, departement, siret } = entiteAidee;
       const demandeMAC = {
         cguValidees: true,
         email,
         departement,
         raisonSociale,
+        siret,
         ...(emailAidant && { relationUtilisateur: emailAidant }),
         ...(identifiantAidant && { identifiantAidant }),
       };

--- a/back/tests/api/mon-aide-cyber/ressourceDemandesAide.spec.ts
+++ b/back/tests/api/mon-aide-cyber/ressourceDemandesAide.spec.ts
@@ -13,6 +13,7 @@ const uneDemandeAide = (parametres?: {
   identifiantAidant?: string;
   departement?: string;
   raisonSociale?: string;
+  siret?: string;
 }): CorpsDemandeAide => ({
   ...(parametres?.emailAidant && { emailAidant: parametres?.emailAidant }),
   ...(parametres?.identifiantAidant && {
@@ -22,6 +23,7 @@ const uneDemandeAide = (parametres?: {
     email: parametres?.email || 'durant@mail.fr',
     departement: parametres?.departement || '12',
     raisonSociale: parametres?.raisonSociale || 'Une raison sociale',
+    siret: parametres?.siret || '01234567891234'
   },
   validationCGU: true,
 });
@@ -57,13 +59,14 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
 
     await request(serveur)
       .post('/api/mon-aide-cyber/demandes-aide')
-      .send(uneDemandeAide({ email: 'durant@mail.fr' }));
+      .send(uneDemandeAide({ email: 'durant@mail.fr', siret: '09876543214321' }));
 
     assert.deepEqual(demandeAideEnvoyee, {
       entiteAidee: {
         email: 'durant@mail.fr',
         departement: '12',
         raisonSociale: 'Une raison sociale',
+        siret: '09876543214321'
       },
     });
   });
@@ -182,6 +185,7 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
             email: 'ceci-n-est-pas-un-mail.fr',
             departement: '12',
             raisonSociale: 'Une raison sociale',
+            siret: '12345678901234',
           },
         });
 
@@ -189,6 +193,25 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
       assert.equal(
         await reponse.body.erreur,
         'Veuillez saisir un email valide.'
+      );
+    });
+
+    it('pour le SIRET de l’entité', async () => {
+      const reponse = await request(serveur)
+        .post('/api/mon-aide-cyber/demandes-aide')
+        .send({
+          validationCGU: true,
+          entiteAidee: {
+            email: 'jean.dupont@email.fr',
+            departement: '12',
+            raisonSociale: 'Une raison sociale',
+          },
+        });
+
+      assert.equal(reponse.status, 400);
+      assert.equal(
+        await reponse.body.erreur,
+        'Veuillez saisir un SIRET valide.'
       );
     });
 
@@ -201,6 +224,7 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
             email: 'jean.dupont@mail.fr',
             departement: '12',
             raisonSociale: 'Une raison sociale',
+            siret: '12345678901234',
           },
         });
 
@@ -220,6 +244,7 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
             email: 'jean.dupont@mail.fr',
             departement: '12',
             raisonSociale: 'Une raison sociale',
+            siret: '12345678901234',
           },
         });
 
@@ -249,7 +274,7 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
         .send({
           email: 'jean.dupont@mail.fr',
           validationCGU: true,
-          entiteAidee: { departement: '01', raisonSociale: '   ' },
+          entiteAidee: { departement: '01', raisonSociale: '   ', siret: '12345678901234', },
         });
 
       assert.equal(reponse.status, 400);
@@ -261,17 +286,22 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
 
     it('pour la validation de l’identifiant Aidant', async () => {
       const reponse = await request(serveur)
-          .post('/api/mon-aide-cyber/demandes-aide')
-          .send({
-            validationCGU: true,
-            entiteAidee: { departement: '33', raisonSociale: 'beta-gouv', email: 'jean.dupont@mail.fr', },
-            identifiantAidant: '  a '
-          });
+        .post('/api/mon-aide-cyber/demandes-aide')
+        .send({
+          validationCGU: true,
+          entiteAidee: {
+            departement: '33',
+            raisonSociale: 'beta-gouv',
+            email: 'jean.dupont@mail.fr',
+            siret: '12345678901234',
+          },
+          identifiantAidant: '  a ',
+        });
 
       assert.equal(reponse.status, 400);
       assert.equal(
-          await reponse.body.erreur,
-          'Veuillez saisir un identifiant Aidant valide.'
+        await reponse.body.erreur,
+        'Veuillez saisir un identifiant Aidant valide.'
       );
     });
   });

--- a/front/lib-svelte/src/demande-aide-mon-aide-cyber/DemandeAideMAC.svelte
+++ b/front/lib-svelte/src/demande-aide-mon-aide-cyber/DemandeAideMAC.svelte
@@ -30,6 +30,7 @@
           email,
           departement: entite.departement,
           raisonSociale: entite.nom,
+          siret: entite.siret,
         },
         validationCGU: cguSontValidees,
         ...(emailUtilisateurMAC && { emailAidant: emailUtilisateurMAC }),

--- a/front/lib-svelte/src/demande-aide-mon-aide-cyber/DonneesFormulaireDemandeAide.ts
+++ b/front/lib-svelte/src/demande-aide-mon-aide-cyber/DonneesFormulaireDemandeAide.ts
@@ -13,6 +13,7 @@ export type CorpsAPIDemandeAide = {
     email: string;
     departement: string;
     raisonSociale: string;
+    siret: string;
   };
   emailAidant?: string;
   identifiantAidant?: string;


### PR DESCRIPTION
MonAideCyber a besoin du SIRET afin de récupérer des informations ultérieurement auprès de l’API recherche entreprise