### PR TITLE
[CORRECTION] Evite de tomber en erreur si suggestions n'est pas défini

### DIFF
--- a/front/lib-svelte/src/ui/formulaire/SelectionOrganisation.svelte
+++ b/front/lib-svelte/src/ui/formulaire/SelectionOrganisation.svelte
@@ -70,7 +70,7 @@
       }
     );
 
-    suggestions = reponse?.data?.suggestions.map(uneSuggestion);
+    suggestions = reponse?.data?.suggestions?.map(uneSuggestion) ?? [];
     suggestionsVisibles = suggestions.length > 0;
   };
 


### PR DESCRIPTION
... En lien avec une remontée d'erreur dans Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/170359/?project=221&referrer=webhooks_plugin. Il semblerait que dans certains cas l'annuaire d'organisation puisse renvoyer une réponse avec des data qui n'ont pas de suggestions défini. Peut être il faudrait mettre en place une gestion d'erreur plus fine dans ce cas afin de données des informations à l'utilisateur et ainsi qu'il puisse se débloquer.