### PR TITLE
[PAGE CONFIDENTIALITÉ] Corrige le débordement des liens

### DIFF
--- a/front/assets/styles/page-statique.scss
+++ b/front/assets/styles/page-statique.scss
@@ -53,6 +53,8 @@
       text-decoration: underline;
       text-underline-offset: 4px;
       text-decoration-thickness: 1px;
+      word-break: normal;
+      overflow-wrap: anywhere;
 
       &:hover {
         text-decoration-thickness: 2px;


### PR DESCRIPTION
...uniquement avec Chromium et dérivés.

Afin d’éviter ce rendu : 
![image](https://github.com/user-attachments/assets/bbc920b6-b462-4211-8cd9-7adf4f2b95e2)
