### PR TITLE
Hache l’email dans l’événement du journal de revendication d’un test

### DIFF
--- a/back/src/bus/cablage.ts
+++ b/back/src/bus/cablage.ts
@@ -44,6 +44,7 @@ export const cableTousLesAbonnes = ({
     consigneEvenementProprieteTestRevendiqueeDansJournal({
       adaptateurJournal,
       adaptateurHorloge,
+      adaptateurChiffrement
     })
   );
   busEvenements.abonnePlusieurs(CompteCree, [

--- a/back/src/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.ts
+++ b/back/src/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.ts
@@ -1,17 +1,25 @@
 import { AdaptateurHorloge } from '../infra/adaptateurHorloge';
 import { AdaptateurJournal } from '../infra/adaptateurJournal';
 import { ProprieteTestRevendiquee } from './evenements/proprieteTestRevendiquee';
+import { AdaptateurChiffrement } from '../infra/adaptateurChiffrement';
 
 export const consigneEvenementProprieteTestRevendiqueeDansJournal = ({
   adaptateurJournal,
   adaptateurHorloge,
+  adaptateurChiffrement,
 }: {
   adaptateurJournal: AdaptateurJournal;
   adaptateurHorloge: AdaptateurHorloge;
+  adaptateurChiffrement: AdaptateurChiffrement;
 }) => {
   return async function (evenement: ProprieteTestRevendiquee) {
     await adaptateurJournal.consigneEvenement({
-      donnees: evenement,
+      donnees: {
+        idUtilisateur: adaptateurChiffrement.hacheSha256(
+          evenement.emailUtilisateur
+        ),
+        idResultatTest: evenement.idResultatTest,
+      },
       type: 'PROPRIETE_TEST_REVENDIQUEE',
       date: adaptateurHorloge.maintenant(),
     });

--- a/back/src/infra/adaptateurJournal.ts
+++ b/back/src/infra/adaptateurJournal.ts
@@ -33,7 +33,7 @@ interface DonneesEvenementMiseAJourFavorisUtilisateur
 interface DonneesEvenementProprieteTestRevendiquee
   extends DonneesCommunesEvenement {
   donnees: {
-    emailUtilisateur: string;
+    idUtilisateur: string;
     idResultatTest: string;
   };
   type: 'PROPRIETE_TEST_REVENDIQUEE';

--- a/back/tests/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.spec.ts
+++ b/back/tests/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.spec.ts
@@ -1,26 +1,42 @@
-import { describe, it } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert';
 import { AdaptateurHorloge } from '../../src/infra/adaptateurHorloge';
 import { AdaptateurJournal } from '../../src/infra/adaptateurJournal';
 import { ProprieteTestRevendiquee } from '../../src/bus/evenements/proprieteTestRevendiquee';
 import { consigneEvenementProprieteTestRevendiqueeDansJournal } from '../../src/bus/consigneEvenementProprieteTestRevendiqueeDansJournal';
+import { AdaptateurChiffrement } from '../../src/infra/adaptateurChiffrement';
 
 describe("L'abonnement qui consigne la revendication de la propriété d'un test dans le journal", () => {
+  let adaptateurHorloge: AdaptateurHorloge;
+  let adaptateurJournal: AdaptateurJournal;
+  let adaptateurChiffrement: AdaptateurChiffrement;
+
+  const consigneEvenementDansJournal = () =>
+    consigneEvenementProprieteTestRevendiqueeDansJournal({
+      adaptateurJournal,
+      adaptateurHorloge,
+      adaptateurChiffrement,
+    });
+
+  beforeEach(() => {
+    adaptateurHorloge = { maintenant: () => new Date() };
+    adaptateurChiffrement = {
+      hacheSha256: (chaineEnClair: string) => `${chaineEnClair}-hache`,
+    };
+  });
+
   it('consigne un évènement de ProprieteTestRevendiquee', async () => {
     let evenementRecu;
-    const adaptateurJournal: AdaptateurJournal = {
+    adaptateurJournal = {
       consigneEvenement: async (donneesEvenement: unknown) => {
         evenementRecu = donneesEvenement;
       },
     };
-    const adaptateurHorloge: AdaptateurHorloge = {
+    adaptateurHorloge = {
       maintenant: () => new Date('2025-03-10'),
     };
 
-    await consigneEvenementProprieteTestRevendiqueeDansJournal({
-      adaptateurJournal,
-      adaptateurHorloge,
-    })(
+    await consigneEvenementDansJournal()(
       new ProprieteTestRevendiquee({
         emailUtilisateur: 'u1@mail.com',
         idResultatTest: '12345',
@@ -29,8 +45,26 @@ describe("L'abonnement qui consigne la revendication de la propriété d'un test
 
     assert.notEqual(evenementRecu, undefined);
     assert.equal(evenementRecu!.type, 'PROPRIETE_TEST_REVENDIQUEE');
-    assert.equal(evenementRecu!.donnees.emailUtilisateur, 'u1@mail.com');
     assert.equal(evenementRecu!.donnees.idResultatTest, '12345');
     assert.deepEqual(evenementRecu!.date, new Date('2025-03-10'));
+  });
+
+  it("hache l'email de l'utilisateur", async () => {
+    let evenementRecu;
+    adaptateurJournal = {
+      consigneEvenement: async (donneesEvenement: unknown) => {
+        evenementRecu = donneesEvenement;
+      },
+    };
+
+    await consigneEvenementDansJournal()(
+      new ProprieteTestRevendiquee({
+        emailUtilisateur: 'u1@mail.com',
+        idResultatTest: '1',
+      })
+    );
+
+    assert.equal(evenementRecu!.donnees.idUtilisateur, 'u1@mail.com-hache');
+    assert.equal(evenementRecu!.donnees.emailUtilisateur, undefined);
   });
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "migre-bdd": "node --env-file=.env --import tsx ./node_modules/knex/bin/cli.js migrate:latest --knexfile back/knexfile.ts",
     "migre-bdd-clever": "node node_modules/knex/bin/cli.js migrate:latest --knexfile dist-back/knexfile.js",
-    "dev": "npx concurrently -n \"SERVEUR,SVELTE,JEKYLL,BDD,MIGRE\" --prefix-colors \"cyan,green,magenta,blue,yellow\" \"node --watch --import tsx --env-file .env ./back/src/serveur.ts\" \"npm run watch --prefix front/lib-svelte\" \"sleep 3 && jekyll build -s ./front -d ./front/_site -w\" \"docker compose up db\" \"sleep 3 && npm run migre-bdd\"",
+    "dev": "npx concurrently -n \"SERVEUR,SVELTE,JEKYLL,BDD,MIGRE\" --prefix-colors \"cyan,green,magenta,blue,yellow\" \"node --watch --import tsx --env-file .env ./back/src/serveur.ts\" \"npm run watch --prefix front/lib-svelte\" \"sleep 5 && jekyll build -s ./front -d ./front/_site -w\" \"docker compose up db\" \"sleep 3 && npm run migre-bdd\"",
     "start": "npm run migre-bdd-clever && node ./dist-back/src/serveur.js",
     "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present"


### PR DESCRIPTION
Actuellement, l’email est envoyé en clair dans l’événement `PROPRIETE_TEST_REVENDIQUEE`. Nous voulons désormais hacher cet email et corriger tous les événements déjà publiés. 