### PR TITLE
Corrige la visibilité des tuiles de niveau sur mobile

### DIFF
--- a/front/lib-svelte/src/test-maturite/TuilesMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/TuilesMaturite.svelte
@@ -1,20 +1,26 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { afterUpdate } from 'svelte';
   import { type NiveauMaturite, niveauxMaturite } from '../niveaux-maturite/NiveauxMaturite.donnees';
 
   export let niveauCourant: NiveauMaturite;
   export let animeTuiles = true;
 
   $: indexNiveauCourant = niveauxMaturite.indexOf(niveauCourant);
-  onMount(() => {
+
+  const scrolleVersTuileCourante = () => {
     let elementCourant: HTMLDivElement | null = document.querySelector(
       '.tuile-niveau.courant',
     );
-    elementCourant?.scrollIntoView({ block: 'center' });
-  });
+    elementCourant!.scrollIntoView({ block: 'center' });
+  };
+
+  const estPetitEcran = window.matchMedia('(max-width: 576px)').matches;
+  const animation = !estPetitEcran && animeTuiles;
+
+  afterUpdate(scrolleVersTuileCourante);
 </script>
 
-<div class="tuiles-niveau" class:avec-animation={animeTuiles}>
+<div class="tuiles-niveau" class:avec-animation={animation}>
   {#each niveauxMaturite as niveau, index (index)}
     <div
       class="tuile-niveau"
@@ -49,8 +55,6 @@
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
     position: relative;
-    left: -20px;
-    justify-content: center;
 
     &:before {
       content: '';


### PR DESCRIPTION
... qui n’étaient plus visible à cause du `justify-content: center` sur le conteneur défilable. Un `scrollIntoView` permet de corriger le problème au moment de la création du composant. Petit problème cependant : ce scroll ne fonctionne pas au moment du montage (`onMount`) du composant. La méthode `afterUpdate` est cependant déprécié en Svelte 5…
![image](https://github.com/user-attachments/assets/bcdc6ff4-4931-466f-998a-fb5199564d54)
