### PR TITLE
[SEO] Ajoute une balise meta `description` à chaque page

### DIFF
--- a/front/_data/meta-description.yml
+++ b/front/_data/meta-description.yml
@@ -1,0 +1,43 @@
+# Ce fichier contient le contenu de la balise
+# meta "description" pour toutes les pages du site
+
+# La syntaxe de chaque ligne est la suivante :
+#<url>: <description>
+#      ^ cette espace est indispensable
+
+/accessibilite/:
+/apres-authentification/:
+/aPropos/:
+/catalogue/:
+/cgu/:
+/confidentialite/:
+/connexion/:
+/contacts/:
+/creation-compte/:
+/cyberdepart/:
+/favoris/:
+/favoris-partages/:
+/inscription/:
+/ma-maturite/:
+/mentionsLegales/:
+/nis2/:
+/niveaux-maturite/:
+/parcours-approfondir/:
+/parcours-debuter/:
+/promouvoir-messervicescyber/:
+/resultats-session-groupe/:
+/securite/:
+/services-anssi/:
+/session-groupe/:
+/statistiques/:
+/test-maturite/:
+/services/conseil-technique.html:
+/services/demainspecialistecyber.html:
+/services/mon-aide-cyber-aidants.html:
+/services/mon-aide-cyber.html:
+/services/mon-espace-nis2.html:
+/services/mon-service-securise.html:
+/services/secnum-academie.html:
+/ressources/cyber-enjeux.html:
+/ressources/cyber-enjeux-pro.html:
+/ressources/secnumedu.html:

--- a/front/_includes/head.html
+++ b/front/_includes/head.html
@@ -11,6 +11,7 @@
   {% endif %}
 
   <title>{{page.titreHtml}}</title>
+  <meta name="description" content="{{ site.data.meta-description[page.url] | escape }}">
 
   <link rel="stylesheet" href="{{ "/assets/styles/site.css" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/styles/boutons.css" | relative_url }}">


### PR DESCRIPTION
...afin de référencer ces pages dans les moteurs de recherche. La configuration se fait dans un fichier au format YML qui contient toutes les descriptions du site.