### PR TITLE
Sauvegarde les hashs des emails utilisateur

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -52,3 +52,10 @@ CRISP_ID_SITE= # Id du site dans le plugin Crisp
 CRISP_CLE_API= # Cle API dans le plugin Crisp
 ARTICLE_PROMOUVOIR_MSC_ID= # Id de l’article Promouvoir MSC dans Crisp
 ARTICLE_PROMOUVOIR_DIAGNOSTIC_CYBER_ID= # Id de l’article Promouvoir le diagnostic cyber dans Crisp
+
+# HACHAGE
+# Secrets utilisés pour le hachage de données. Les variables sont au format HACHAGE_SECRET_DE_HACHAGE_n où n est un
+# nombre entier, unique, et les différentes variables d'environnement `HACHAGE_SECRET_DE_HACHAGE_n` ont
+# des valeurs de n consécutives et commençant par 1
+HACHAGE_SECRET_DE_HACHAGE_1= # Secret à utiliser pour le hachage HMAC
+#HACHAGE_SECRET_DE_HACHAGE_2= # Second secret à utiliser pour le hachage HMAC

--- a/back/migrations/20250612122433_ajouteColonneHacheEmailUtilisateurs.ts
+++ b/back/migrations/20250612122433_ajouteColonneHacheEmailUtilisateurs.ts
@@ -1,0 +1,15 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('utilisateurs', (table) => {
+    table.string('email_hache').index();
+    table.string('email_hache_256').index();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('utilisateurs', (table) => {
+    table.dropColumn('email_hache');
+    table.dropColumn('email_hache_256');
+  });
+}

--- a/back/migrations/20250612123742_remplisColonnesHacheEmailUtilisateur.ts
+++ b/back/migrations/20250612123742_remplisColonnesHacheEmailUtilisateur.ts
@@ -1,0 +1,41 @@
+import {createHmac} from "node:crypto";
+import {createHash} from "crypto";
+import type { Knex } from 'knex';
+
+const hacheAvecHMAC = (valeur: string) => {
+  if (!process.env.HACHAGE_SECRET_DE_HACHAGE_1) {
+    throw new Error("Missing HACHAGE_SECRET_DE_HACHAGE_1");
+  }
+
+  return createHmac('sha256', process.env.HACHAGE_SECRET_DE_HACHAGE_1)
+    .update(valeur)
+    .digest('hex');
+};
+
+const hacheSha256 = (valeur: string) =>
+  createHash('sha256')
+  .update(valeur + process.env.CHIFFREMENT_SEL_DE_HASHAGE)
+  .digest('hex');
+
+exports.up = async (knex: Knex) => {
+
+  await knex.transaction(async (trx) => {
+    const utilisateurs = await trx('utilisateurs');
+
+    const maj = utilisateurs.map(({ email }) => {
+
+      const emailHache256 = hacheSha256(email);
+      const emailHacheHMAC = `v1:${hacheAvecHMAC(email)}`;
+
+      return trx('utilisateurs').where({ email }).update({ email_hache: emailHacheHMAC, email_hache_256: emailHache256 });
+    });
+
+    await Promise.all(maj);
+  });
+};
+
+exports.down = async (knex: Knex) => {
+  await knex.transaction(async (trx) =>
+    trx('utilisateurs').update({ email_hache: null, email_hache_256: null })
+  );
+};

--- a/back/migrations/20250613070435_creationTableVersioningSecretHachage.ts
+++ b/back/migrations/20250613070435_creationTableVersioningSecretHachage.ts
@@ -1,0 +1,11 @@
+import type { Knex } from 'knex';
+
+exports.up = (knex: Knex) =>
+  knex.schema.createTable('secrets_hachage', (table) => {
+    table.integer('version');
+    table.primary(['version']);
+    table.text('empreinte');
+    table.datetime('date_migration').defaultTo(knex.fn.now());
+  });
+
+exports.down = (knex: Knex) => knex.schema.dropTable('secrets_hachage');

--- a/back/package.json
+++ b/back/package.json
@@ -32,7 +32,9 @@
   "dependencies": {
     "@lab-anssi/lib": "^1.2.0",
     "@sentry/node": "^7.102.1",
+    "@types/bcrypt": "^5.0.2",
     "axios": "^1.8.2",
+    "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cookie-session": "^2.1.0",
     "express": "^4.21.2",

--- a/back/src/admin/consoleAdministration.ts
+++ b/back/src/admin/consoleAdministration.ts
@@ -294,7 +294,7 @@ export class ConsoleAdministration {
     });
   }
 
-  async sauvegardeLesSecretsDeHachage() {
+  async sauvegardeLesEmpreintesDesSecretsDeHachage() {
     await this.knexMSC.transaction(async (trx) => {
       const tousLesSecretsDeHachage = adaptateurEnvironnement
         .hachage()

--- a/back/src/admin/consoleAdministration.ts
+++ b/back/src/admin/consoleAdministration.ts
@@ -293,6 +293,24 @@ export class ConsoleAdministration {
       });
     });
   }
+
+  async sauvegardeLesSecretsDeHachage() {
+    await this.knexMSC.transaction(async (trx) => {
+      const tousLesSecretsDeHachage = adaptateurEnvironnement
+        .hachage()
+        .tousLesSecretsDeHachage();
+
+      const maj = tousLesSecretsDeHachage.map(async ({ version, secret }) => {
+        const empreinte = await this.adaptateurHachage.hacheBCrypt(secret);
+        return trx('secrets_hachage')
+          .insert({ version, empreinte })
+          .onConflict()
+          .ignore();
+      });
+
+      await Promise.all(maj);
+    });
+  }
 }
 
 // Usage example depuis le dossier /back

--- a/back/src/admin/consoleAdministration.ts
+++ b/back/src/admin/consoleAdministration.ts
@@ -28,7 +28,7 @@ import {
 export class ConsoleAdministration {
   private entrepotUtilisateur: EntrepotUtilisateur;
   private adaptateurEmail: AdaptateurEmail;
-  private adaptateurChiffrement: AdaptateurChiffrement;
+  private readonly adaptateurChiffrement: AdaptateurChiffrement;
   private readonly adaptateurHachage: AdaptateurHachage;
   private entrepotFavori: EntrepotFavori;
   private knexJournal: Knex.Knex;
@@ -36,15 +36,17 @@ export class ConsoleAdministration {
 
   constructor() {
     const adaptateurProfilAnssi = fabriqueAdaptateurProfilAnssi();
-    this.entrepotUtilisateur = new EntrepotUtilisateurMPAPostgres(
-      adaptateurProfilAnssi,
-      adaptateurRechercheEntreprise
-    );
+    this.adaptateurChiffrement = fabriqueAdaptateurChiffrement();
     this.adaptateurHachage = fabriqueAdaptateurHachage({
       adaptateurEnvironnement,
     });
+    this.entrepotUtilisateur = new EntrepotUtilisateurMPAPostgres({
+      adaptateurProfilAnssi,
+      adaptateurRechercheEntreprise,
+      adaptateurChiffrement: this.adaptateurChiffrement,
+      adaptateurHachage: this.adaptateurHachage,
+    });
     this.adaptateurEmail = fabriqueAdaptateurEmail();
-    this.adaptateurChiffrement = fabriqueAdaptateurChiffrement();
     this.entrepotFavori = new EntrepotFavoriPostgres();
     const configDuJournal = {
       client: 'pg',

--- a/back/src/bus/cablage.ts
+++ b/back/src/bus/cablage.ts
@@ -9,27 +9,25 @@ import { CompteCree } from './evenements/compteCree';
 import { envoieEmailCreationCompte } from './envoieEmailCreationCompte';
 import { AdaptateurEmail } from '../metier/adaptateurEmail';
 import { creeContactBrevo } from './creeContactBrevo';
-import {
-  consigneEvenementCompteCreeDansJournal,
-} from './consigneEvenementCompteCreeDansJournal';
-import { AdaptateurChiffrement } from '../infra/adaptateurChiffrement';
+import { consigneEvenementCompteCreeDansJournal } from './consigneEvenementCompteCreeDansJournal';
 import { consigneEvenementMAJFavorisUtilisateurDansJournal } from './consigneEvenementMAJFavorisUtilisateurDansJournal';
 import { MiseAJourFavorisUtilisateur } from './miseAJourFavorisUtilisateur';
 import { EntrepotFavori } from '../metier/entrepotFavori';
+import { AdaptateurHachage } from '../infra/adaptateurHachage';
 
 export const cableTousLesAbonnes = ({
   busEvenements,
   adaptateurEmail,
   adaptateurJournal,
   adaptateurHorloge,
-  adaptateurChiffrement,
+  adaptateurHachage,
   entrepotFavori,
 }: {
   busEvenements: BusEvenements;
   adaptateurEmail: AdaptateurEmail;
   adaptateurJournal: AdaptateurJournal;
   adaptateurHorloge: AdaptateurHorloge;
-  adaptateurChiffrement: AdaptateurChiffrement;
+  adaptateurHachage: AdaptateurHachage;
   entrepotFavori: EntrepotFavori;
 }) => {
   busEvenements.abonne(
@@ -44,7 +42,7 @@ export const cableTousLesAbonnes = ({
     consigneEvenementProprieteTestRevendiqueeDansJournal({
       adaptateurJournal,
       adaptateurHorloge,
-      adaptateurChiffrement
+      adaptateurHachage,
     })
   );
   busEvenements.abonnePlusieurs(CompteCree, [
@@ -57,7 +55,7 @@ export const cableTousLesAbonnes = ({
     consigneEvenementCompteCreeDansJournal({
       adaptateurJournal,
       adaptateurHorloge,
-      adaptateurChiffrement,
+      adaptateurHachage,
     }),
   ]);
   busEvenements.abonne(
@@ -65,7 +63,7 @@ export const cableTousLesAbonnes = ({
     consigneEvenementMAJFavorisUtilisateurDansJournal({
       adaptateurJournal,
       adaptateurHorloge,
-      adaptateurChiffrement,
+      adaptateurHachage,
       entrepotFavori,
     })
   );

--- a/back/src/bus/consigneEvenementCompteCreeDansJournal.ts
+++ b/back/src/bus/consigneEvenementCompteCreeDansJournal.ts
@@ -1,21 +1,21 @@
 import { AdaptateurHorloge } from '../infra/adaptateurHorloge';
 import { AdaptateurJournal } from '../infra/adaptateurJournal';
 import { CompteCree } from './evenements/compteCree';
-import { AdaptateurChiffrement } from '../infra/adaptateurChiffrement';
+import { AdaptateurHachage } from '../infra/adaptateurHachage';
 
 export const consigneEvenementCompteCreeDansJournal = ({
   adaptateurJournal,
   adaptateurHorloge,
-  adaptateurChiffrement,
+  adaptateurHachage,
 }: {
   adaptateurJournal: AdaptateurJournal;
   adaptateurHorloge: AdaptateurHorloge;
-  adaptateurChiffrement: AdaptateurChiffrement;
+  adaptateurHachage: AdaptateurHachage;
 }) => {
   return async function (evenement: CompteCree) {
     await adaptateurJournal.consigneEvenement({
       donnees: {
-        idUtilisateur: adaptateurChiffrement.hacheSha256(evenement.email),
+        idUtilisateur: adaptateurHachage.hache(evenement.email),
       },
       type: 'NOUVEL_UTILISATEUR_INSCRIT',
       date: adaptateurHorloge.maintenant(),

--- a/back/src/bus/consigneEvenementMAJFavorisUtilisateurDansJournal.ts
+++ b/back/src/bus/consigneEvenementMAJFavorisUtilisateurDansJournal.ts
@@ -1,18 +1,18 @@
 import { AdaptateurHorloge } from '../infra/adaptateurHorloge';
 import { AdaptateurJournal } from '../infra/adaptateurJournal';
-import { AdaptateurChiffrement } from '../infra/adaptateurChiffrement';
 import { MiseAJourFavorisUtilisateur } from './miseAJourFavorisUtilisateur';
 import { EntrepotFavori } from '../metier/entrepotFavori';
+import { AdaptateurHachage } from '../infra/adaptateurHachage';
 
 export const consigneEvenementMAJFavorisUtilisateurDansJournal = ({
   adaptateurJournal,
   adaptateurHorloge,
-  adaptateurChiffrement,
+  adaptateurHachage,
   entrepotFavori,
 }: {
   adaptateurJournal: AdaptateurJournal;
   adaptateurHorloge: AdaptateurHorloge;
-  adaptateurChiffrement: AdaptateurChiffrement;
+  adaptateurHachage: AdaptateurHachage;
   entrepotFavori: EntrepotFavori;
 }) => {
   return async function (evenement: MiseAJourFavorisUtilisateur) {
@@ -21,7 +21,7 @@ export const consigneEvenementMAJFavorisUtilisateurDansJournal = ({
     ).map(({ idItemCyber }) => idItemCyber);
     await adaptateurJournal.consigneEvenement({
       donnees: {
-        idUtilisateur: adaptateurChiffrement.hacheSha256(evenement.email),
+        idUtilisateur: adaptateurHachage.hache(evenement.email),
         listeIdFavoris,
       },
       type: 'MISE_A_JOUR_FAVORIS_UTILISATEUR',

--- a/back/src/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.ts
+++ b/back/src/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.ts
@@ -1,23 +1,21 @@
 import { AdaptateurHorloge } from '../infra/adaptateurHorloge';
 import { AdaptateurJournal } from '../infra/adaptateurJournal';
 import { ProprieteTestRevendiquee } from './evenements/proprieteTestRevendiquee';
-import { AdaptateurChiffrement } from '../infra/adaptateurChiffrement';
+import { AdaptateurHachage } from '../infra/adaptateurHachage';
 
 export const consigneEvenementProprieteTestRevendiqueeDansJournal = ({
   adaptateurJournal,
   adaptateurHorloge,
-  adaptateurChiffrement,
+  adaptateurHachage,
 }: {
   adaptateurJournal: AdaptateurJournal;
   adaptateurHorloge: AdaptateurHorloge;
-  adaptateurChiffrement: AdaptateurChiffrement;
+  adaptateurHachage: AdaptateurHachage;
 }) => {
   return async function (evenement: ProprieteTestRevendiquee) {
     await adaptateurJournal.consigneEvenement({
       donnees: {
-        idUtilisateur: adaptateurChiffrement.hacheSha256(
-          evenement.emailUtilisateur
-        ),
+        idUtilisateur: adaptateurHachage.hache(evenement.emailUtilisateur),
         idResultatTest: evenement.idResultatTest,
       },
       type: 'PROPRIETE_TEST_REVENDIQUEE',

--- a/back/src/infra/adaptateurHachage.ts
+++ b/back/src/infra/adaptateurHachage.ts
@@ -4,11 +4,15 @@ import { createHmac } from 'node:crypto';
 const hacheAvecUnSeulSecret = (valeur: string, secret: string) =>
   createHmac('sha256', secret).update(valeur).digest('hex');
 
+export type AdaptateurHachage = {
+  hache: (valeur: string) => string;
+};
+
 export const adaptateurHachage = ({
   adaptateurEnvironnement,
 }: {
   adaptateurEnvironnement: AdaptateurEnvironnement;
-}) => ({
+}): AdaptateurHachage => ({
   hache: (valeur: string): string => {
     const secrets = adaptateurEnvironnement.hachage().tousLesSecretsDeHachage();
 

--- a/back/src/infra/adaptateurHachage.ts
+++ b/back/src/infra/adaptateurHachage.ts
@@ -1,10 +1,14 @@
 import { AdaptateurEnvironnement } from './adaptateurEnvironnement';
 import { createHmac } from 'node:crypto';
+import { hash as hashBCrypt } from 'bcrypt';
+
+const NOMBRE_DE_PASSES = 10;
 
 const hacheAvecUnSeulSecret = (valeur: string, secret: string) =>
   createHmac('sha256', secret).update(valeur).digest('hex');
 
 export type AdaptateurHachage = {
+  hacheBCrypt: (valeur: string) => Promise<string>;
   hache: (valeur: string) => string;
 };
 
@@ -13,6 +17,11 @@ export const fabriqueAdaptateurHachage = ({
 }: {
   adaptateurEnvironnement: AdaptateurEnvironnement;
 }): AdaptateurHachage => ({
+
+  hacheBCrypt: async (chaineEnClair: string): Promise<string> => {
+    return hashBCrypt(chaineEnClair, NOMBRE_DE_PASSES);
+  },
+
   hache: (valeur: string): string => {
     const secrets = adaptateurEnvironnement.hachage().tousLesSecretsDeHachage();
 

--- a/back/src/infra/adaptateurHachage.ts
+++ b/back/src/infra/adaptateurHachage.ts
@@ -1,0 +1,26 @@
+import { AdaptateurEnvironnement } from './adaptateurEnvironnement';
+import { createHmac } from 'node:crypto';
+
+const hacheAvecUnSeulSecret = (valeur: string, secret: string) =>
+  createHmac('sha256', secret).update(valeur).digest('hex');
+
+export const adaptateurHachage = ({
+  adaptateurEnvironnement,
+}: {
+  adaptateurEnvironnement: AdaptateurEnvironnement;
+}) => ({
+  hache: (valeur: string): string => {
+    const secrets = adaptateurEnvironnement.hachage().tousLesSecretsDeHachage();
+
+    const hashFinal = secrets.reduce(
+      (acc, { secret }) => hacheAvecUnSeulSecret(acc, secret),
+      valeur
+    );
+
+    const version = secrets
+      .map(({ version: numVersion }) => `v${numVersion}`)
+      .join('-');
+
+    return `${version}:${hashFinal}`;
+  },
+});

--- a/back/src/infra/adaptateurHachage.ts
+++ b/back/src/infra/adaptateurHachage.ts
@@ -8,7 +8,7 @@ export type AdaptateurHachage = {
   hache: (valeur: string) => string;
 };
 
-export const adaptateurHachage = ({
+export const fabriqueAdaptateurHachage = ({
   adaptateurEnvironnement,
 }: {
   adaptateurEnvironnement: AdaptateurEnvironnement;

--- a/back/src/infra/entrepotUtilisateurMPAPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurMPAPostgres.ts
@@ -6,19 +6,32 @@ import { UtilisateurBDD } from './utilisateurBDD';
 import { AdaptateurProfilAnssi } from './adaptateurProfilAnssi';
 import { AdaptateurRechercheEntreprise } from './adaptateurRechercheEntreprise';
 import pThrottle from 'p-throttle';
+import { AdaptateurHachage } from './adaptateurHachage';
+import { AdaptateurChiffrement } from './adaptateurChiffrement';
 
 export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
   knex: Knex.Knex;
   adaptateurProfilAnssi: AdaptateurProfilAnssi;
   adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise;
+  adaptateurChiffrement: AdaptateurChiffrement;
+  adaptateurHachage: AdaptateurHachage;
 
-  constructor(
-    adaptateurProfilAnssi: AdaptateurProfilAnssi,
-    adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise
-  ) {
+  constructor({
+    adaptateurProfilAnssi,
+    adaptateurRechercheEntreprise,
+    adaptateurHachage,
+    adaptateurChiffrement,
+  }: {
+    adaptateurProfilAnssi: AdaptateurProfilAnssi;
+    adaptateurRechercheEntreprise: AdaptateurRechercheEntreprise;
+    adaptateurHachage: AdaptateurHachage;
+    adaptateurChiffrement: AdaptateurChiffrement;
+  }) {
     this.knex = Knex(config);
     this.adaptateurProfilAnssi = adaptateurProfilAnssi;
     this.adaptateurRechercheEntreprise = adaptateurRechercheEntreprise;
+    this.adaptateurChiffrement = adaptateurChiffrement;
+    this.adaptateurHachage = adaptateurHachage;
   }
 
   private chiffreDonneesUtilisateur(utilisateur: Utilisateur): UtilisateurBDD {
@@ -26,6 +39,10 @@ export class EntrepotUtilisateurMPAPostgres implements EntrepotUtilisateur {
       email: utilisateur.email,
       donnees: utilisateur,
       id_liste_favoris: utilisateur.idListeFavoris,
+      email_hache: this.adaptateurHachage.hache(utilisateur.email),
+      email_hache_256: this.adaptateurChiffrement.hacheSha256(
+        utilisateur.email
+      ),
     };
   }
 

--- a/back/src/infra/utilisateurBDD.ts
+++ b/back/src/infra/utilisateurBDD.ts
@@ -1,5 +1,7 @@
 export interface UtilisateurBDD {
   email: string;
+  email_hache: string;
+  email_hache_256: string;
   donnees: {
     email: string;
     cguAcceptees: boolean;

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -49,6 +49,8 @@ const cmsCrisp = new CmsCrisp(crispIdSite, crispCleApi);
 
 const entrepotSessionDeGroupe = new EntrepotSessionDeGroupePostgres();
 
+adaptateurEnvironnement.hachage().tousLesSecretsDeHachage();
+
 creeServeur({
   fournisseurChemin,
   middleware: fabriqueMiddleware({ adaptateurJWT, fournisseurChemin }),

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -20,10 +20,17 @@ import { fabriqueAdaptateurChiffrement } from './infra/adaptateurChiffrement';
 import { CmsCrisp } from '@lab-anssi/lib';
 import { EntrepotSessionDeGroupePostgres } from './infra/EntrepotSessionDeGroupePostgres';
 import { GenerateurAleatoireCodeSessionDeGroupe } from './metier/generateurCodeSessionDeGroupe';
+import { fabriqueAdaptateurHachage } from './infra/adaptateurHachage';
 
 const adaptateurEmail = fabriqueAdaptateurEmail();
 const adaptateurChiffrement = fabriqueAdaptateurChiffrement();
 const adaptateurJournal = fabriqueAdaptateurJournal();
+const adaptateurProfilAnssi = fabriqueAdaptateurProfilAnssi();
+const adaptateurMonAideCyber = fabriqueAdaptateurMonAideCyber();
+const adaptateurHachage = fabriqueAdaptateurHachage({
+  adaptateurEnvironnement,
+});
+
 const entrepotFavori = new EntrepotFavoriPostgres();
 
 const busEvenements = new BusEvenements();
@@ -32,12 +39,9 @@ cableTousLesAbonnes({
   adaptateurEmail,
   adaptateurJournal,
   adaptateurHorloge,
-  adaptateurChiffrement,
+  adaptateurHachage,
   entrepotFavori,
 });
-
-const adaptateurProfilAnssi = fabriqueAdaptateurProfilAnssi();
-const adaptateurMonAideCyber = fabriqueAdaptateurMonAideCyber();
 
 const crispIdSite = process.env.CRISP_ID_SITE;
 const crispCleApi = process.env.CRISP_CLE_API;
@@ -58,10 +62,12 @@ creeServeur({
   adaptateurJWT,
   adaptateurGestionErreur: adaptateurGestionErreurSentry,
   busEvenements,
-  entrepotUtilisateur: new EntrepotUtilisateurMPAPostgres(
+  entrepotUtilisateur: new EntrepotUtilisateurMPAPostgres({
     adaptateurProfilAnssi,
-    adaptateurRechercheEntreprise
-  ),
+    adaptateurRechercheEntreprise,
+    adaptateurChiffrement,
+    adaptateurHachage,
+  }),
   reseau: {
     trustProxy: adaptateurEnvironnement.serveur().trustProxy(),
     maxRequetesParMinutes: adaptateurEnvironnement

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -13,6 +13,7 @@ import { EntrepotFavoriMemoire } from '../persistance/entrepotFavoriMemoire';
 import { MockCmsCrisp } from '../mockCmsCrisp';
 import { AdaptateurEnvironnement } from '../../src/infra/adaptateurEnvironnement';
 import { EntrepotSessionDeGroupeMemoire } from '../persistance/EntrepotSessionDeGroupeMemoire';
+import {AdaptateurHachage} from "../../src/infra/adaptateurHachage";
 
 export const fauxFournisseurDeChemin = {
   cheminPageJekyll: (_: string) =>
@@ -111,6 +112,11 @@ export const fauxAdaptateurEnvironnement: AdaptateurEnvironnement = {
 
 const fauxGenerateurCodeSessionDeGroupe = {
   genere: async () => 'hello',
+};
+
+export const fauxAdaptateurHachage: AdaptateurHachage = {
+  hache: (valeur: string): string => `${valeur}-hache`,
+  hacheBCrypt: async (valeur: string): Promise<string> => `${valeur}-hacheBCrypt`,
 };
 
 export const configurationDeTestDuServeur: ConfigurationServeur = {

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -84,6 +84,9 @@ export const fauxMiddleware: Middleware = {
 const fauxAdaptateurMonAideCyber = { creeDemandeAide: () => Promise.resolve() };
 
 export const fauxAdaptateurEnvironnement: AdaptateurEnvironnement = {
+  hachage: () => ({
+    tousLesSecretsDeHachage: () => [{ version: 1, secret: 'secret' }],
+  }),
   urlBaseMSC: () => 'http://localhost',
   oidc: () => ({
     urlRedirectionApresAuthentification: () => '',

--- a/back/tests/bus/consigneEvenementCompteCreeDansJournal.spec.ts
+++ b/back/tests/bus/consigneEvenementCompteCreeDansJournal.spec.ts
@@ -5,6 +5,7 @@ import { AdaptateurJournal } from '../../src/infra/adaptateurJournal';
 import { CompteCree } from '../../src/bus/evenements/compteCree';
 import { consigneEvenementCompteCreeDansJournal } from '../../src/bus/consigneEvenementCompteCreeDansJournal';
 import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
+import {fauxAdaptateurHachage} from "../api/fauxObjets";
 
 describe("L'abonnement qui consigne la création d'un compte utilisateur dans le journal", () => {
   it('consigne un évènement de NouvelUtilisateurInscrit', async () => {
@@ -19,6 +20,7 @@ describe("L'abonnement qui consigne la création d'un compte utilisateur dans le
     };
 
     const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
       hache: (valeur) => `${valeur}-hacheHMAC`,
     };
 

--- a/back/tests/bus/consigneEvenementCompteCreeDansJournal.spec.ts
+++ b/back/tests/bus/consigneEvenementCompteCreeDansJournal.spec.ts
@@ -4,7 +4,7 @@ import { AdaptateurHorloge } from '../../src/infra/adaptateurHorloge';
 import { AdaptateurJournal } from '../../src/infra/adaptateurJournal';
 import { CompteCree } from '../../src/bus/evenements/compteCree';
 import { consigneEvenementCompteCreeDansJournal } from '../../src/bus/consigneEvenementCompteCreeDansJournal';
-import { AdaptateurChiffrement } from '../../src/infra/adaptateurChiffrement';
+import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
 
 describe("L'abonnement qui consigne la création d'un compte utilisateur dans le journal", () => {
   it('consigne un évènement de NouvelUtilisateurInscrit', async () => {
@@ -18,14 +18,14 @@ describe("L'abonnement qui consigne la création d'un compte utilisateur dans le
       maintenant: () => new Date('2025-03-10'),
     };
 
-    const adaptateurChiffrement: AdaptateurChiffrement = {
-      hacheSha256: (chaineEnClair: string) => `${chaineEnClair}-hache`,
+    const adaptateurHachage: AdaptateurHachage = {
+      hache: (valeur) => `${valeur}-hacheHMAC`,
     };
 
     await consigneEvenementCompteCreeDansJournal({
       adaptateurJournal,
       adaptateurHorloge,
-      adaptateurChiffrement,
+      adaptateurHachage,
     })(
       new CompteCree({
         email: 'u1@mail.com',
@@ -37,7 +37,7 @@ describe("L'abonnement qui consigne la création d'un compte utilisateur dans le
 
     assert.deepEqual(evenementRecu, {
       type: 'NOUVEL_UTILISATEUR_INSCRIT',
-      donnees: { idUtilisateur: 'u1@mail.com-hache' },
+      donnees: { idUtilisateur: 'u1@mail.com-hacheHMAC' },
       date: new Date('2025-03-10'),
     });
   });

--- a/back/tests/bus/consigneEvenementMAJFavorisUtilisateurDansJournal.spec.ts
+++ b/back/tests/bus/consigneEvenementMAJFavorisUtilisateurDansJournal.spec.ts
@@ -6,6 +6,7 @@ import { consigneEvenementMAJFavorisUtilisateurDansJournal } from '../../src/bus
 import { MiseAJourFavorisUtilisateur } from '../../src/bus/miseAJourFavorisUtilisateur';
 import { EntrepotFavoriMemoire } from '../persistance/entrepotFavoriMemoire';
 import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
+import {fauxAdaptateurHachage} from "../api/fauxObjets";
 
 describe("L'abonnement qui consigne la mise à jour des favoris de l'utilisateur dans le journal", () => {
   it('consigne un évènement de MAJFavorisUtilisateur', async () => {
@@ -20,6 +21,7 @@ describe("L'abonnement qui consigne la mise à jour des favoris de l'utilisateur
     };
 
     const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
       hache: (valeur) => `${valeur}-hacheHMAC`,
     };
 

--- a/back/tests/bus/consigneEvenementMAJFavorisUtilisateurDansJournal.spec.ts
+++ b/back/tests/bus/consigneEvenementMAJFavorisUtilisateurDansJournal.spec.ts
@@ -2,10 +2,10 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { AdaptateurHorloge } from '../../src/infra/adaptateurHorloge';
 import { AdaptateurJournal } from '../../src/infra/adaptateurJournal';
-import { AdaptateurChiffrement } from '../../src/infra/adaptateurChiffrement';
 import { consigneEvenementMAJFavorisUtilisateurDansJournal } from '../../src/bus/consigneEvenementMAJFavorisUtilisateurDansJournal';
 import { MiseAJourFavorisUtilisateur } from '../../src/bus/miseAJourFavorisUtilisateur';
 import { EntrepotFavoriMemoire } from '../persistance/entrepotFavoriMemoire';
+import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
 
 describe("L'abonnement qui consigne la mise à jour des favoris de l'utilisateur dans le journal", () => {
   it('consigne un évènement de MAJFavorisUtilisateur', async () => {
@@ -19,8 +19,8 @@ describe("L'abonnement qui consigne la mise à jour des favoris de l'utilisateur
       maintenant: () => new Date('2025-04-16'),
     };
 
-    const adaptateurChiffrement: AdaptateurChiffrement = {
-      hacheSha256: (chaineEnClair: string) => `${chaineEnClair}-hache`,
+    const adaptateurHachage: AdaptateurHachage = {
+      hache: (valeur) => `${valeur}-hacheHMAC`,
     };
 
     const entrepotFavori = new EntrepotFavoriMemoire();
@@ -36,7 +36,7 @@ describe("L'abonnement qui consigne la mise à jour des favoris de l'utilisateur
     await consigneEvenementMAJFavorisUtilisateurDansJournal({
       adaptateurJournal,
       adaptateurHorloge,
-      adaptateurChiffrement,
+      adaptateurHachage,
       entrepotFavori,
     })(
       new MiseAJourFavorisUtilisateur({
@@ -46,7 +46,10 @@ describe("L'abonnement qui consigne la mise à jour des favoris de l'utilisateur
 
     assert.notEqual(evenementRecu, undefined);
     assert.equal(evenementRecu!.type, 'MISE_A_JOUR_FAVORIS_UTILISATEUR');
-    assert.equal(evenementRecu!.donnees.idUtilisateur, 'email@mail.com-hache');
+    assert.equal(
+      evenementRecu!.donnees.idUtilisateur,
+      'email@mail.com-hacheHMAC'
+    );
     assert.equal(evenementRecu!.donnees.listeIdFavoris.length, 2);
     assert.deepEqual(evenementRecu!.date, new Date('2025-04-16'));
   });

--- a/back/tests/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.spec.ts
+++ b/back/tests/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.spec.ts
@@ -5,6 +5,7 @@ import { AdaptateurJournal } from '../../src/infra/adaptateurJournal';
 import { ProprieteTestRevendiquee } from '../../src/bus/evenements/proprieteTestRevendiquee';
 import { consigneEvenementProprieteTestRevendiqueeDansJournal } from '../../src/bus/consigneEvenementProprieteTestRevendiqueeDansJournal';
 import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
+import {fauxAdaptateurHachage} from "../api/fauxObjets";
 
 describe("L'abonnement qui consigne la revendication de la propriété d'un test dans le journal", () => {
   let adaptateurHorloge: AdaptateurHorloge;
@@ -22,6 +23,7 @@ describe("L'abonnement qui consigne la revendication de la propriété d'un test
   beforeEach(() => {
     adaptateurHorloge = { maintenant: () => new Date() };
     adaptateurHachage = {
+      ...fauxAdaptateurHachage,
       hache: (valeur) => `${valeur}-hacheHMAC`,
     };
   });

--- a/back/tests/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.spec.ts
+++ b/back/tests/bus/consigneEvenementProprieteTestRevendiqueeDansJournal.spec.ts
@@ -4,24 +4,25 @@ import { AdaptateurHorloge } from '../../src/infra/adaptateurHorloge';
 import { AdaptateurJournal } from '../../src/infra/adaptateurJournal';
 import { ProprieteTestRevendiquee } from '../../src/bus/evenements/proprieteTestRevendiquee';
 import { consigneEvenementProprieteTestRevendiqueeDansJournal } from '../../src/bus/consigneEvenementProprieteTestRevendiqueeDansJournal';
-import { AdaptateurChiffrement } from '../../src/infra/adaptateurChiffrement';
+import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
 
 describe("L'abonnement qui consigne la revendication de la propriété d'un test dans le journal", () => {
   let adaptateurHorloge: AdaptateurHorloge;
   let adaptateurJournal: AdaptateurJournal;
-  let adaptateurChiffrement: AdaptateurChiffrement;
+  let adaptateurHachage: AdaptateurHachage;
 
-  const consigneEvenementDansJournal = () =>
-    consigneEvenementProprieteTestRevendiqueeDansJournal({
+  const consigneEvenementDansJournal = () => {
+    return consigneEvenementProprieteTestRevendiqueeDansJournal({
       adaptateurJournal,
       adaptateurHorloge,
-      adaptateurChiffrement,
+      adaptateurHachage,
     });
+  };
 
   beforeEach(() => {
     adaptateurHorloge = { maintenant: () => new Date() };
-    adaptateurChiffrement = {
-      hacheSha256: (chaineEnClair: string) => `${chaineEnClair}-hache`,
+    adaptateurHachage = {
+      hache: (valeur) => `${valeur}-hacheHMAC`,
     };
   });
 
@@ -64,7 +65,7 @@ describe("L'abonnement qui consigne la revendication de la propriété d'un test
       })
     );
 
-    assert.equal(evenementRecu!.donnees.idUtilisateur, 'u1@mail.com-hache');
+    assert.equal(evenementRecu!.donnees.idUtilisateur, 'u1@mail.com-hacheHMAC');
     assert.equal(evenementRecu!.donnees.emailUtilisateur, undefined);
   });
 });

--- a/back/tests/infra/adaptateurEnvironnement.spec.ts
+++ b/back/tests/infra/adaptateurEnvironnement.spec.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { adaptateurEnvironnement } from '../../src/infra/adaptateurEnvironnement';
+import assert from 'node:assert';
+
+describe("L'adaptateur environnement", () => {
+  let envActuel: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    envActuel = process.env;
+  });
+
+  afterEach(() => {
+    process.env = envActuel;
+  });
+
+  it('sait charger les secrets', async () => {
+    process.env = {
+      HACHAGE_SECRET_DE_HACHAGE_1: 'secret1',
+      HACHAGE_SECRET_DE_HACHAGE_2: 'secret2',
+    };
+
+    const tousLesSecretsDeHachage = adaptateurEnvironnement
+      .hachage()
+      .tousLesSecretsDeHachage();
+
+    assert.deepEqual(tousLesSecretsDeHachage, [
+      { version: 1, secret: 'secret1' },
+      { version: 2, secret: 'secret2' },
+    ]);
+  });
+
+  it('charge les secrets dans le bon ordre', async () => {
+    process.env = {
+      HACHAGE_SECRET_DE_HACHAGE_1: 'secret1',
+      HACHAGE_SECRET_DE_HACHAGE_3: 'secret3',
+      HACHAGE_SECRET_DE_HACHAGE_2: 'secret2',
+    };
+
+    const tousLesSecretsDeHachage = adaptateurEnvironnement
+      .hachage()
+      .tousLesSecretsDeHachage();
+
+    assert.deepEqual(tousLesSecretsDeHachage, [
+      { version: 1, secret: 'secret1' },
+      { version: 2, secret: 'secret2' },
+      { version: 3, secret: 'secret3' },
+    ]);
+  });
+
+  it('ne charge pas les secrets qui ne correspondent pas au format indiqué', async () => {
+    process.env = {
+      HACHAGE_SECRET_DE_HACHAGE_1: 'secret1',
+      HACHAGE_SECRET_DE_HACHAGE_V3: 'secret3',
+      HACHAGE_SECRET_DE_HACHAGE_2: 'secret2',
+    };
+
+    const tousLesSecretsDeHachage = adaptateurEnvironnement
+      .hachage()
+      .tousLesSecretsDeHachage();
+
+    assert.deepEqual(tousLesSecretsDeHachage, [
+      { version: 1, secret: 'secret1' },
+      { version: 2, secret: 'secret2' },
+    ]);
+  });
+
+  it('utilise des entiers pour les versions', () => {
+    process.env = { HACHAGE_SECRET_DE_HACHAGE_1: 'secret1' };
+
+    const tousLesSecretsDeHachage = adaptateurEnvironnement
+      .hachage()
+      .tousLesSecretsDeHachage();
+
+    assert.equal(tousLesSecretsDeHachage[0].version, 1);
+  });
+
+  it('lance une exception si un secret est vide', async () => {
+    process.env = {
+      HACHAGE_SECRET_DE_HACHAGE_1: '',
+    };
+
+    assert.throws(
+      () => {
+        adaptateurEnvironnement.hachage().tousLesSecretsDeHachage();
+      },
+      {
+        message: `Le secret de hachage HACHAGE_SECRET_DE_HACHAGE_1 ne doit pas être vide`,
+      }
+    );
+  });
+
+  it("lance une exception s'il n'y a aucun secret", () => {
+    process.env = {};
+
+    assert.throws(
+      () => {
+        adaptateurEnvironnement.hachage().tousLesSecretsDeHachage();
+      },
+      { message: `Il doit y avoir au moins un secret de hachage` }
+    );
+  });
+
+  it('ignore les clés qui ne concernent pas le hachage', () => {
+    process.env = {
+      URL_BASE: '',
+      HACHAGE_SECRET_DE_HACHAGE_1: 'ok',
+    };
+
+    const secrets = adaptateurEnvironnement.hachage().tousLesSecretsDeHachage();
+
+    assert.equal(secrets.length, 1);
+  });
+});

--- a/back/tests/infra/adaptateurHachage.spec.ts
+++ b/back/tests/infra/adaptateurHachage.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { adaptateurHachage } from '../../src/infra/adaptateurHachage';
+import { fabriqueAdaptateurHachage } from '../../src/infra/adaptateurHachage';
 import { AdaptateurEnvironnement } from '../../src/infra/adaptateurEnvironnement';
 import { fauxAdaptateurEnvironnement } from '../api/fauxObjets';
 
@@ -14,7 +14,7 @@ describe("L'adaptateur de hachage", () => {
         }),
       };
 
-      const hache = adaptateurHachage({
+      const hache = fabriqueAdaptateurHachage({
         adaptateurEnvironnement,
       }).hache('7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
 
@@ -35,7 +35,7 @@ describe("L'adaptateur de hachage", () => {
         }),
       };
 
-      const hache = adaptateurHachage({
+      const hache = fabriqueAdaptateurHachage({
         adaptateurEnvironnement,
       }).hache('7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
 
@@ -53,7 +53,7 @@ describe("L'adaptateur de hachage", () => {
         }),
       };
 
-      const hache = adaptateurHachage({
+      const hache = fabriqueAdaptateurHachage({
         adaptateurEnvironnement,
       }).hache('7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
 

--- a/back/tests/infra/adaptateurHachage.spec.ts
+++ b/back/tests/infra/adaptateurHachage.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { adaptateurHachage } from '../../src/infra/adaptateurHachage';
+import { AdaptateurEnvironnement } from '../../src/infra/adaptateurEnvironnement';
+import { fauxAdaptateurEnvironnement } from '../api/fauxObjets';
+
+describe("L'adaptateur de hachage", () => {
+  describe('sur demande de hachage HMAC', () => {
+    it('hache avec un secret', async () => {
+      const adaptateurEnvironnement: AdaptateurEnvironnement = {
+        ...fauxAdaptateurEnvironnement,
+        hachage: () => ({
+          tousLesSecretsDeHachage: () => [{ version: 1, secret: 'chut' }],
+        }),
+      };
+
+      const hache = adaptateurHachage({
+        adaptateurEnvironnement,
+      }).hache('7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
+
+      assert.equal(
+        hache,
+        'v1:1cf9d6256a25545991bb031f1bbec7837b6e76b71e567acb83d88ee82dc07178'
+      );
+    });
+
+    it('hache avec deux secrets', async () => {
+      const adaptateurEnvironnement: AdaptateurEnvironnement = {
+        ...fauxAdaptateurEnvironnement,
+        hachage: () => ({
+          tousLesSecretsDeHachage: () => [
+            { version: 1, secret: 'chut' },
+            { version: 2, secret: 'tais-toi' },
+          ],
+        }),
+      };
+
+      const hache = adaptateurHachage({
+        adaptateurEnvironnement,
+      }).hache('7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
+
+      assert.equal(
+        hache,
+        'v1-v2:ddb368b08519541e0e9f7c910358facac8107c763672536da06b484cec18249b'
+      );
+    });
+
+    it('si aucun ?', () => {
+      const adaptateurEnvironnement: AdaptateurEnvironnement = {
+        ...fauxAdaptateurEnvironnement,
+        hachage: () => ({
+          tousLesSecretsDeHachage: () => [],
+        }),
+      };
+
+      const hache = adaptateurHachage({
+        adaptateurEnvironnement,
+      }).hache('7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
+
+      assert.equal(hache, ':7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,9 @@
       "dependencies": {
         "@lab-anssi/lib": "^1.2.0",
         "@sentry/node": "^7.102.1",
+        "@types/bcrypt": "^5.0.2",
         "axios": "^1.8.2",
+        "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
         "cookie-session": "^2.1.0",
         "express": "^4.21.2",
@@ -1250,6 +1252,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -1388,7 +1399,6 @@
       "version": "22.13.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
       "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -1972,6 +1982,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -4180,6 +4204,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-mocks-http": {
@@ -6655,7 +6699,6 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
...afin de pouvoir ensuite chiffrer les données de l'utilisateur

> [!WARNING]
> Il faut ajouter la variable d'environnement `HACHAGE_SECRET_DE_HACHAGE_1` avant déploiement et sauvegarder précieusement cette valeur

> [!IMPORTANT]
> Il faut après déploiement exécuter la migration `consoleAdmin.sauvegardeLesEmpreintesDesSecretsDeHachage()` et `consoleAdmin.migreLesHashSha256DuJournal()` 