### PR TITLE
[CORRECTION] Corrige l’affichage des caractères en UTF-8 fournis dans le query param de la demande d’Aide

### DIFF
--- a/front/lib-svelte/src/demande-aide-mon-aide-cyber/FormulaireDemandeAide.svelte
+++ b/front/lib-svelte/src/demande-aide-mon-aide-cyber/FormulaireDemandeAide.svelte
@@ -40,7 +40,11 @@
       libelleChampUtilisateurMAC = "Nom de l'Aidant cyber";
       utilisateurMACPrerempli = true;
       estEnRelationAvecUnUtilisateur = true;
-      emailUtilisateurMAC = atob(decodeURIComponent(nomUsage));
+      emailUtilisateurMAC = new TextDecoder().decode(
+              Uint8Array.from(atob(decodeURIComponent(nomUsage)), (car) =>
+                      car.charCodeAt(0)
+              )
+      )
       return
     }
   });


### PR DESCRIPTION
**Contexte**
Formulaire de demande d’Aide MAC

**Reproduction**
- Utiliser le chemin suivant sur un environnement (dev, démo, prod…) `cyberdepart?nom-usage=RnLDqWTDqXJpYyBNZW5zZQ%3D%3D&identifiant-utilisateur-mac=83680f4e-9e32-48cc-a4df-2a8aa9d2615e`
- Vérifier l’affichage des données dans le formulaire

**Résultat constaté**
Le nom de affiché dans le champs `Nom de l'Aidant cyber` est `FrÃ©dÃ©ric Mense`
<img width="834" alt="Capture d’écran 2025-06-13 à 10 39 03" src="https://github.com/user-attachments/assets/f81b2f38-ef26-462e-b68b-a6eacd6d3a9d" />

**Résultat attendu**
Le nom de affiché dans le champs `Nom de l'Aidant cyber` est `Frédéric Mense`