### PR TITLE
Verifie les secrets de hachage au démarrage

### DIFF
--- a/back/src/infra/adaptateurEnvironnement.ts
+++ b/back/src/infra/adaptateurEnvironnement.ts
@@ -77,7 +77,7 @@ const adaptateurEnvironnement: AdaptateurEnvironnement = {
         version: string;
         valeur: string;
       };
-      const secrets = Object.entries(process.env)
+      return Object.entries(process.env)
         .map(([cle, valeur]) => {
           const matches = cle.match(/HACHAGE_SECRET_DE_HACHAGE_(\d+)/);
           const version = matches ? matches[1] : undefined;
@@ -98,10 +98,6 @@ const adaptateurEnvironnement: AdaptateurEnvironnement = {
         .sort(
           ({ version: version1 }, { version: version2 }) => version1 - version2
         );
-      if (secrets.length === 0) {
-        throw new Error('Il doit y avoir au moins un secret de hachage');
-      }
-      return secrets;
     },
   }),
 };

--- a/back/src/infra/adaptateurHachage.ts
+++ b/back/src/infra/adaptateurHachage.ts
@@ -1,6 +1,6 @@
 import { AdaptateurEnvironnement } from './adaptateurEnvironnement';
 import { createHmac } from 'node:crypto';
-import { hash as hashBCrypt } from 'bcrypt';
+import { hash as hashBCrypt, compare as compareBCrypt } from 'bcrypt';
 
 const NOMBRE_DE_PASSES = 10;
 
@@ -9,6 +9,7 @@ const hacheAvecUnSeulSecret = (valeur: string, secret: string) =>
 
 export type AdaptateurHachage = {
   hacheBCrypt: (valeur: string) => Promise<string>;
+  compareBCrypt: (valeurEnClair: string, empreinte: string) => Promise<boolean>;
   hache: (valeur: string) => string;
 };
 
@@ -17,10 +18,11 @@ export const fabriqueAdaptateurHachage = ({
 }: {
   adaptateurEnvironnement: AdaptateurEnvironnement;
 }): AdaptateurHachage => ({
+  hacheBCrypt: async (chaineEnClair: string): Promise<string> =>
+    hashBCrypt(chaineEnClair, NOMBRE_DE_PASSES),
 
-  hacheBCrypt: async (chaineEnClair: string): Promise<string> => {
-    return hashBCrypt(chaineEnClair, NOMBRE_DE_PASSES);
-  },
+  compareBCrypt: (valeurEnClair, empreinte) =>
+    compareBCrypt(valeurEnClair, empreinte),
 
   hache: (valeur: string): string => {
     const secrets = adaptateurEnvironnement.hachage().tousLesSecretsDeHachage();

--- a/back/src/infra/entrepotSecretHachagePostgres.ts
+++ b/back/src/infra/entrepotSecretHachagePostgres.ts
@@ -1,0 +1,19 @@
+import Knex from 'knex';
+import config from '../../knexfile';
+
+export interface EntrepotSecretHachage {
+  tous: () => Promise<{ version: number, empreinte: string }[]>;
+}
+
+export class EntrepotSecretHachagePostgres implements EntrepotSecretHachage {
+  knex: Knex.Knex;
+
+  constructor() {
+    this.knex = Knex(config);
+  }
+
+  async tous(): Promise<{ version: number, empreinte: string }[]> {
+    const empreintes = await this.knex('secrets_hachage');
+    return empreintes.map(({version, empreinte}) => ({version, empreinte}));
+  }
+}

--- a/back/src/infra/serviceVerificationCoherenceSecretsHachage.ts
+++ b/back/src/infra/serviceVerificationCoherenceSecretsHachage.ts
@@ -1,0 +1,74 @@
+import { EntrepotSecretHachage } from './entrepotSecretHachagePostgres';
+import { AdaptateurHachage } from './adaptateurHachage';
+import { AdaptateurEnvironnement } from './adaptateurEnvironnement';
+
+const verifieQueChaqueSecretEstCoherent = async (
+  tousLesSecretsDeHachageDeLaConfig: { version: number; secret: string }[],
+  empreintesDesSecretsAppliques: { version: number; empreinte: string }[],
+  adaptateurHachage: AdaptateurHachage
+) => {
+  for (let i = 0; i < tousLesSecretsDeHachageDeLaConfig.length; i += 1) {
+    const { version: versionDeLaConfig, secret: valeurSecretEnClair } =
+      tousLesSecretsDeHachageDeLaConfig[i];
+    const leSecretAppliqueCorrespondant = empreintesDesSecretsAppliques.find(
+      ({ version: versionEnBase }) => versionEnBase === versionDeLaConfig
+    );
+
+    if (!leSecretAppliqueCorrespondant) {
+      throw new Error(
+        `💥 La version ${versionDeLaConfig} du secret noté dans la config est manquante dans la persistance.`
+      );
+    }
+    const estValide = await adaptateurHachage.compareBCrypt(
+      valeurSecretEnClair,
+      leSecretAppliqueCorrespondant.empreinte
+    );
+
+    if (!estValide) {
+      throw new Error(
+        `💥 La version ${versionDeLaConfig} du secret de la config a une valeur différente de celle déjà appliquée.`
+      );
+    }
+  }
+
+  for (let i = 0; i < empreintesDesSecretsAppliques.length; i += 1) {
+    const { version: versionAppliquee } = empreintesDesSecretsAppliques[i];
+    if (
+      !tousLesSecretsDeHachageDeLaConfig.some(
+        ({ version: versionDansLaConfig }) =>
+          versionAppliquee === versionDansLaConfig
+      )
+    ) {
+      throw new Error(
+        `💥 La version ${versionAppliquee} du secret déjà appliquée est manquante dans la config.`
+      );
+    }
+  }
+};
+
+export const fabriqueServiceVerificationCoherenceSecretsHachage = ({
+  adaptateurHachage,
+  entrepotSecretHachage,
+  adaptateurEnvironnement,
+}: {
+  entrepotSecretHachage: EntrepotSecretHachage;
+  adaptateurHachage: AdaptateurHachage;
+  adaptateurEnvironnement: AdaptateurEnvironnement;
+}) => ({
+  verifieCoherenceSecrets: async () => {
+    const empreintesDesSecretsAppliques = await entrepotSecretHachage.tous();
+    const tousLesSecretsDeHachageDeLaConfig = adaptateurEnvironnement
+      .hachage()
+      .tousLesSecretsDeHachage();
+
+    if (tousLesSecretsDeHachageDeLaConfig.length === 0) {
+      throw new Error('💥 Aucun secret de hachage dans la config.');
+    }
+
+    await verifieQueChaqueSecretEstCoherent(
+      tousLesSecretsDeHachageDeLaConfig,
+      empreintesDesSecretsAppliques,
+      adaptateurHachage
+    );
+  },
+});

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -117,6 +117,7 @@ const fauxGenerateurCodeSessionDeGroupe = {
 export const fauxAdaptateurHachage: AdaptateurHachage = {
   hache: (valeur: string): string => `${valeur}-hache`,
   hacheBCrypt: async (valeur: string): Promise<string> => `${valeur}-hacheBCrypt`,
+  compareBCrypt: async (_valeurEnClair: string, _empreinte: string): Promise<boolean> => true,
 };
 
 export const configurationDeTestDuServeur: ConfigurationServeur = {

--- a/back/tests/infra/adaptateurEnvironnement.spec.ts
+++ b/back/tests/infra/adaptateurEnvironnement.spec.ts
@@ -89,17 +89,6 @@ describe("L'adaptateur environnement", () => {
     );
   });
 
-  it("lance une exception s'il n'y a aucun secret", () => {
-    process.env = {};
-
-    assert.throws(
-      () => {
-        adaptateurEnvironnement.hachage().tousLesSecretsDeHachage();
-      },
-      { message: `Il doit y avoir au moins un secret de hachage` }
-    );
-  });
-
   it('ignore les clés qui ne concernent pas le hachage', () => {
     process.env = {
       URL_BASE: '',

--- a/back/tests/infra/serviceVerificationCoherenceSecretsHachage.spec.ts
+++ b/back/tests/infra/serviceVerificationCoherenceSecretsHachage.spec.ts
@@ -1,0 +1,206 @@
+import { describe, it } from 'node:test';
+import {
+  fauxAdaptateurEnvironnement,
+  fauxAdaptateurHachage,
+} from '../api/fauxObjets';
+import { fabriqueServiceVerificationCoherenceSecretsHachage } from '../../src/infra/serviceVerificationCoherenceSecretsHachage';
+import { EntrepotSecretHachage } from '../../src/infra/entrepotSecretHachagePostgres';
+import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
+import assert from 'assert';
+
+describe('Le service de vérification de la cohérence des secrets de hachage', () => {
+  it('jette une erreur si un secret est invalide', async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [
+          { version: 1, secret: 'unAutreSecret' },
+        ],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [{ version: 1, empreinte: 'secret-crypte' }],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async () => false,
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await assert.rejects(
+      () => service.verifieCoherenceSecrets(),
+      {
+        message:
+          '💥 La version 1 du secret de la config a une valeur différente de celle déjà appliquée.',
+      },
+      'La méthode aurait dû lever une erreur'
+    );
+  });
+
+  it("jette une erreur si le deuxième secret est invalide, peu importe l'ordre", async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [
+          { version: 2, secret: 'unAutresecret' },
+          { version: 1, secret: 'secret' },
+        ],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [
+        { version: 1, empreinte: 'secret-crypte' },
+        { version: 2, empreinte: 'secret2-crypte' },
+      ],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async (secretEnClair) => secretEnClair !== 'unAutresecret',
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await assert.rejects(
+      () => service.verifieCoherenceSecrets(),
+      {
+        message:
+          '💥 La version 2 du secret de la config a une valeur différente de celle déjà appliquée.',
+      },
+      'La méthode aurait dû lever une erreur'
+    );
+  });
+
+  it('ne fait rien si tous les secrets sont valides', async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [
+          { version: 1, secret: 'secret' },
+          { version: 2, secret: 'secret2' },
+        ],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [
+        { version: 1, empreinte: 'secret-crypte' },
+        { version: 2, empreinte: 'secret2-crypte' },
+      ],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async () => true,
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await assert.doesNotReject(() => service.verifieCoherenceSecrets());
+  });
+
+  it("jette une erreur si un secret n'est pas présent dans la persistance", async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [
+          { version: 1, secret: 'secret' },
+          { version: 2, secret: 'secret2' },
+        ],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [{ version: 2, empreinte: 'secret2-crypte' }],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async () => true,
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await assert.rejects(
+      () => service.verifieCoherenceSecrets(),
+      {
+        message:
+          '💥 La version 1 du secret noté dans la config est manquante dans la persistance.',
+      },
+      'La méthode aurait dû lever une erreur'
+    );
+  });
+
+  it("jette une erreur si un secret de la persistance n'est pas présent dans la config", async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [{ version: 2, secret: 'secret2' }],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [
+        { version: 2, empreinte: 'secret2-crypte' },
+        { version: 1, empreinte: 'secret-crypte' },
+      ],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async () => true,
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await assert.rejects(
+      () => service.verifieCoherenceSecrets(),
+      {
+        message:
+          '💥 La version 1 du secret déjà appliquée est manquante dans la config.',
+      },
+      'La méthode aurait dû lever une erreur'
+    );
+  });
+
+  it("jette une erreur si aucun secret n'est présent dans la config", async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [],
+      }),
+    };
+
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [{ version: 1, empreinte: 'secret-crypte' }],
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage: fauxAdaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await assert.rejects(
+      () => service.verifieCoherenceSecrets(),
+      {
+        message: '💥 Aucun secret de hachage dans la config.',
+      },
+      'La méthode aurait dû lever une erreur'
+    );
+  });
+});


### PR DESCRIPTION
On vérifie au démarrage les empreintes stockées dans la tables `secrets_hachage` en les comparant avec les variables de la configuration du serveur. 
En cas de discordance, le serveur s’arrête. 

:warning: If faut merger #346 avant celle-ci. 