### PR TITLE
[CORRECTION] Utilise un contenu plus flexible sur le catalogue

### DIFF
--- a/front/assets/styles/carte-item.scss
+++ b/front/assets/styles/carte-item.scss
@@ -42,10 +42,7 @@
     margin: 0;
     border-top-right-radius: 8px;
     border-top-left-radius: 8px;
-    flex: 1;
-    box-sizing: border-box;
-    gap: 8px;
-    height: 156px;
+    flex-basis: 154px;
 
     img {
       height: 131px;
@@ -87,7 +84,7 @@
     padding: 24px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    flex: 1;
 
     .nom-item {
       margin: 0;
@@ -103,7 +100,6 @@
       font-weight: bold;
       font-size: 1.25rem;
       line-height: 1.75rem;
-      height: 84px;
       overflow: hidden;
       margin-bottom: 8px;
     }

--- a/front/lib-svelte/src/catalogue/ContenuCarteItem.svelte
+++ b/front/lib-svelte/src/catalogue/ContenuCarteItem.svelte
@@ -65,12 +65,12 @@
     padding: 24px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
 
     .en-tete {
       display: flex;
       justify-content: space-between;
       align-items: center;
+      margin-bottom: 8px;
     }
 
     .nom-item {


### PR DESCRIPTION
afin de permettre à la zone de tags de prendre de la place dans la zone de titre

Avant : 
<img width="621" alt="Capture d’écran 2025-06-16 à 10 18 39" src="https://github.com/user-attachments/assets/8955842d-f9e5-4146-8232-f447a00fb6f0" />

Après : 
<img width="493" alt="Capture d’écran 2025-06-16 à 10 19 51" src="https://github.com/user-attachments/assets/f0e6ed95-5e70-483b-870f-b5415ceaeb72" />
