### PR TITLE
[SOIN] Corrige des erreurs eslint dans les tests

### DIFF
--- a/front/lib-svelte/test/catalogue/stores/catalogue.store.spec.ts
+++ b/front/lib-svelte/test/catalogue/stores/catalogue.store.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { get } from 'svelte/store';
 import { catalogueStore } from '../../../src/catalogue/stores/catalogue.store';
 import { livretEnJeux, mss } from './objetsExemples';
-import { ItemCyber } from '../../../src/catalogue/Catalogue.types';
+import type { ItemCyber } from '../../../src/catalogue/Catalogue.types';
 
 describe('Le store du catalogue', () => {
   it("est une collection d'items", () => {

--- a/front/lib-svelte/test/catalogue/stores/catalogueFiltre.store.spec.ts
+++ b/front/lib-svelte/test/catalogue/stores/catalogueFiltre.store.spec.ts
@@ -15,7 +15,7 @@ import {
   BesoinCyber,
   DroitAcces,
   FormatRessource,
-  ItemCyber,
+  type ItemCyber,
   Source,
   Typologie,
 } from '../../../src/catalogue/Catalogue.types';

--- a/front/lib-svelte/test/catalogue/stores/nombreResultats.store.spec.ts
+++ b/front/lib-svelte/test/catalogue/stores/nombreResultats.store.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   DroitAcces,
   FormatRessource,
-  ItemCyber,
+  type ItemCyber,
   Source,
   Typologie,
 } from '../../../src/catalogue/Catalogue.types';
@@ -59,6 +59,7 @@ describe('Le store du nombre de résultats', () => {
 
     it("lorsque un service n'a pas de droit d'acces", () => {
       const sansDroitAcces = monEspaceNIS2();
+      // @ts-expect-error On simule ici un markdown invalide
       delete sansDroitAcces.droitsAcces;
       initialiseStoreCatalogue([sansDroitAcces]);
 

--- a/front/lib-svelte/test/catalogue/stores/rechercheParDroitAcces.store.spec.ts
+++ b/front/lib-svelte/test/catalogue/stores/rechercheParDroitAcces.store.spec.ts
@@ -19,6 +19,7 @@ describe("La recherche par droit d'accès", () => {
   it("reste robuste lorsqu'un item n'a pas de droit d'acces", () => {
     rechercheParDroitAcces.set([DroitAcces.ACCES_LIBRE]);
     const sansDroitDAcces = { ...mss() };
+    // @ts-expect-error On simule ici un markdown invalide
     delete sansDroitDAcces.droitsAcces;
 
     const resultat = rechercheParDroitAcces.ok(sansDroitDAcces);

--- a/front/lib-svelte/test/stores/profil.store.spec.ts
+++ b/front/lib-svelte/test/stores/profil.store.spec.ts
@@ -29,9 +29,9 @@ describe('Le store du profil', () => {
   it('assigne la valeur du profil au store', async () => {
     const profil = get(profilStore);
 
-    expect(profil.prenom).toEqual('Jeanne');
-    expect(profil.nom).toEqual('Dupond');
-    expect(profil.email).toEqual('jeanne.dupond@mail.fr');
-    expect(profil.siret).toEqual('123456789');
+    expect(profil!.prenom).toEqual('Jeanne');
+    expect(profil!.nom).toEqual('Dupond');
+    expect(profil!.email).toEqual('jeanne.dupond@mail.fr');
+    expect(profil!.siret).toEqual('123456789');
   });
 });


### PR DESCRIPTION
Quelques erreurs sont restées dans les tests depuis que nous avons activé eslint