### PR TITLE
Consigne les retours d’expérience dans le journal

### DIFF
--- a/back/src/bus/cablage.ts
+++ b/back/src/bus/cablage.ts
@@ -14,6 +14,8 @@ import { consigneEvenementMAJFavorisUtilisateurDansJournal } from './consigneEve
 import { MiseAJourFavorisUtilisateur } from './miseAJourFavorisUtilisateur';
 import { EntrepotFavori } from '../metier/entrepotFavori';
 import { AdaptateurHachage } from '../infra/adaptateurHachage';
+import { RetourExperienceDonne } from './evenements/retourExperienceDonne';
+import { consigneEvenementRetourExperienceDonneDansJournal } from './consigneEvenementRetourExperienceDonneDansJournal';
 
 export const cableTousLesAbonnes = ({
   busEvenements,
@@ -65,6 +67,14 @@ export const cableTousLesAbonnes = ({
       adaptateurHorloge,
       adaptateurHachage,
       entrepotFavori,
+    })
+  );
+  busEvenements.abonne(
+    RetourExperienceDonne,
+    consigneEvenementRetourExperienceDonneDansJournal({
+      adaptateurJournal,
+      adaptateurHorloge,
+      adaptateurHachage,
     })
   );
 };

--- a/back/src/bus/consigneEvenementRetourExperienceDonneDansJournal.ts
+++ b/back/src/bus/consigneEvenementRetourExperienceDonneDansJournal.ts
@@ -1,0 +1,28 @@
+import { AdaptateurJournal } from '../infra/adaptateurJournal';
+import { AdaptateurHorloge } from '../infra/adaptateurHorloge';
+import { AdaptateurHachage } from '../infra/adaptateurHachage';
+import { RetourExperienceDonne } from './evenements/retourExperienceDonne';
+
+export const consigneEvenementRetourExperienceDonneDansJournal = ({
+  adaptateurJournal,
+  adaptateurHorloge,
+  adaptateurHachage,
+}: {
+  adaptateurJournal: AdaptateurJournal;
+  adaptateurHorloge: AdaptateurHorloge;
+  adaptateurHachage: AdaptateurHachage;
+}) => {
+  return async (evenement: RetourExperienceDonne) => {
+    const idUtilisateur = evenement.emailDeContact
+      ? adaptateurHachage.hache(evenement.emailDeContact)
+      : undefined;
+    await adaptateurJournal.consigneEvenement({
+      donnees: {
+        idUtilisateur,
+        raison: evenement.raison,
+      },
+      type: 'RETOUR_EXPERIENCE_DONNE',
+      date: adaptateurHorloge.maintenant(),
+    });
+  };
+};

--- a/back/src/bus/evenements/retourExperienceDonne.ts
+++ b/back/src/bus/evenements/retourExperienceDonne.ts
@@ -1,13 +1,13 @@
 export class RetourExperienceDonne {
   raison: string;
-  emailDeContact: string;
+  emailDeContact: string | undefined;
 
   constructor({
     raison,
     emailDeContact,
   }: {
     raison: string;
-    emailDeContact: string;
+    emailDeContact?: string;
   }) {
     this.raison = raison;
     this.emailDeContact = emailDeContact;

--- a/back/src/bus/evenements/retourExperienceDonne.ts
+++ b/back/src/bus/evenements/retourExperienceDonne.ts
@@ -1,0 +1,15 @@
+export class RetourExperienceDonne {
+  raison: string;
+  emailDeContact: string;
+
+  constructor({
+    raison,
+    emailDeContact,
+  }: {
+    raison: string;
+    emailDeContact: string;
+  }) {
+    this.raison = raison;
+    this.emailDeContact = emailDeContact;
+  }
+}

--- a/back/src/infra/adaptateurJournal.ts
+++ b/back/src/infra/adaptateurJournal.ts
@@ -8,7 +8,8 @@ export type DonneesEvenement =
   | DonneesEvenementNouvelUtilisateur
   | DonneesEvenementProprieteTestRevendiquee
   | DonneesEvenementTestRealise
-  | DonneesEvenementMiseAJourFavorisUtilisateur;
+  | DonneesEvenementMiseAJourFavorisUtilisateur
+  | DonneesEvenementRetourExperienceDonne;
 
 interface DonneesCommunesEvenement {
   date: Date;
@@ -48,6 +49,15 @@ interface DonneesEvenementTestRealise extends DonneesCommunesEvenement {
     codeSessionGroupe?: string | undefined;
   };
   type: 'TEST_REALISE';
+}
+
+interface DonneesEvenementRetourExperienceDonne
+  extends DonneesCommunesEvenement {
+  donnees: {
+    raison: string;
+    idUtilisateur: string | undefined;
+  };
+  type: 'RETOUR_EXPERIENCE_DONNE';
 }
 
 export type AdaptateurJournal = {

--- a/back/tests/bus/consigneEvenementRetourExperienceDonneDansJournal.spec.ts
+++ b/back/tests/bus/consigneEvenementRetourExperienceDonneDansJournal.spec.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+import { AdaptateurHorloge } from '../../src/infra/adaptateurHorloge';
+import { AdaptateurJournal } from '../../src/infra/adaptateurJournal';
+import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
+import { fauxAdaptateurHachage } from '../api/fauxObjets';
+import { consigneEvenementRetourExperienceDonneDansJournal } from '../../src/bus/consigneEvenementRetourExperienceDonneDansJournal';
+import { RetourExperienceDonne } from '../../src/bus/evenements/retourExperienceDonne';
+
+describe("L'abonnement qui consigne le don d'un retour d’expérience dans le journal", () => {
+  let adaptateurHorloge: AdaptateurHorloge;
+  let adaptateurJournal: AdaptateurJournal;
+  let adaptateurHachage: AdaptateurHachage;
+
+  const consigneEvenementDansJournal = () => {
+    return consigneEvenementRetourExperienceDonneDansJournal({
+      adaptateurJournal,
+      adaptateurHorloge,
+      adaptateurHachage,
+    });
+  };
+
+  beforeEach(() => {
+    adaptateurHorloge = { maintenant: () => new Date() };
+    adaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      hache: (valeur) => `${valeur}-hacheHMAC`,
+    };
+  });
+
+  it('consigne un évènement de RetourExperienceDonne', async () => {
+    let evenementRecu;
+    adaptateurJournal = {
+      consigneEvenement: async (donneesEvenement: unknown) => {
+        evenementRecu = donneesEvenement;
+      },
+    };
+    adaptateurHorloge = {
+      maintenant: () => new Date('2025-03-10'),
+    };
+
+    await consigneEvenementDansJournal()(
+      new RetourExperienceDonne({
+        raison: 'pas-besoin',
+        emailDeContact: 'jean@dupont.fr',
+      })
+    );
+
+    assert.notEqual(evenementRecu, undefined);
+    assert.equal(evenementRecu!.type, 'RETOUR_EXPERIENCE_DONNE');
+    assert.equal(evenementRecu!.donnees.raison, 'pas-besoin');
+    assert.deepEqual(evenementRecu!.date, new Date('2025-03-10'));
+  });
+
+  it("hache l'email de l'utilisateur", async () => {
+    let evenementRecu;
+    adaptateurJournal = {
+      consigneEvenement: async (donneesEvenement: unknown) => {
+        evenementRecu = donneesEvenement;
+      },
+    };
+
+    await consigneEvenementDansJournal()(
+      new RetourExperienceDonne({
+        raison: 'x',
+        emailDeContact: 'jean@dupont.fr',
+      })
+    );
+
+    assert.equal(
+      evenementRecu!.donnees.idUtilisateur,
+      `jean@dupont.fr-hacheHMAC`
+    );
+  });
+
+  it("ne consigne pas d'email si celui-ci est absent", async () => {
+    let evenementRecu;
+    adaptateurJournal = {
+      consigneEvenement: async (donneesEvenement: unknown) => {
+        evenementRecu = donneesEvenement;
+      },
+    };
+
+    await consigneEvenementDansJournal()(
+      new RetourExperienceDonne({ raison: 'x' })
+    );
+
+    assert.equal(evenementRecu!.donnees.idUtilisateur, undefined);
+  });
+});


### PR DESCRIPTION
Publie un événement et le consigne dans le journal. L’événement est `RETOUR_EXPERIENCE_DONNE` et il contient la raison et le mail de contact (éventuel) haché. 