### PR TITLE
[DIAG] N’affiche pas la modale de sortie en cas de succès

### DIFF
--- a/front/lib-svelte/src/demande-aide-mon-aide-cyber/DemandeAideMAC.svelte
+++ b/front/lib-svelte/src/demande-aide-mon-aide-cyber/DemandeAideMAC.svelte
@@ -27,7 +27,7 @@
 
     const ecouteSortieSouris = (e: MouseEvent) => {
       const positionEnHauteur = e.pageY;
-      if (positionEnHauteur < 250) {
+      if (positionEnHauteur < 250 && !enSucces) {
         body.removeEventListener('mousemove', ecouteSortieSouris);
         localStorage.setItem('sortieDiagnosticAffichee', 'true');
         dialogueSortie.affiche();


### PR DESCRIPTION
...pour ne pas voir cette modale si l’utilisateur a correctement soumis le formulaire