### PR TITLE
Corrige les erreurs dans la base de données des résultats de test

### DIFF
--- a/back/migrations/20250709074649_supprimeReponsesTestInvalides.ts
+++ b/back/migrations/20250709074649_supprimeReponsesTestInvalides.ts
@@ -1,0 +1,26 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.transaction(async (trx) => {
+    const lignes = await trx('resultats_test');
+    const promesses = lignes.map((ligne) => {
+      if (
+        !Number.isInteger(ligne.reponses.budget) ||
+        !Number.isInteger(ligne.reponses.pilotage) ||
+        !Number.isInteger(ligne.reponses.posture) ||
+        !Number.isInteger(ligne.reponses['adoption-solutions']) ||
+        !Number.isInteger(ligne.reponses['prise-en-compte-risque']) ||
+        !Number.isInteger(ligne.reponses['ressources-humaines'])
+      ) {
+        return trx('resultats_test').where({ id: ligne.id }).delete();
+      }
+    });
+    const suppressions = promesses.filter(p=>p!== undefined);
+    console.log(`Suppression de ${suppressions.length} lignes`);
+    return Promise.all(suppressions);
+  });
+}
+
+export async function down(_knex: Knex): Promise<void> {
+  // on ne souhaite pas rétablir des données corrompues qui ont été supprimées
+}


### PR DESCRIPTION
...suite à la création de données corrompues dans les réponses qui n’ont pas été correctement validées par l’API.