### PR TITLE
Applique les retours graphiques sur onglet historique

### DIFF
--- a/front/lib-svelte/src/test-maturite/HistoriqueTests.svelte
+++ b/front/lib-svelte/src/test-maturite/HistoriqueTests.svelte
@@ -61,6 +61,7 @@
     affichePubMsc={false}
     afficheRappelReponses
     dateRealisation={new Date(resultatTestSelectionne.dateRealisation)}
+    defilementAutomatique={false}
   />
 {:else}
   <section>

--- a/front/lib-svelte/src/test-maturite/MaturiteUtilisateur.svelte
+++ b/front/lib-svelte/src/test-maturite/MaturiteUtilisateur.svelte
@@ -37,4 +37,5 @@
   afficheRappelReponses={true}
   animeTuiles={false}
   {dateRealisationDernierTest}
+  defilementAutomatique={false}
 />

--- a/front/lib-svelte/src/test-maturite/OngletsTest.svelte
+++ b/front/lib-svelte/src/test-maturite/OngletsTest.svelte
@@ -4,11 +4,20 @@
 </script>
 
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import Onglet from '../ui/Onglet.svelte';
   import ConteneurOnglets from '../ui/ConteneurOnglets.svelte';
   import { profilStore } from '../stores/profil.store';
 
   export let ongletActif: CleOnglet | undefined;
+
+  const emet = createEventDispatcher<{
+    reclicHistorique: null;
+  }>();
+
+  const reclicHistorique = () => {
+    emet('reclicHistorique');
+  };
 </script>
 
 {#if $profilStore && ongletActif}
@@ -20,7 +29,11 @@
           cetOnglet="votre-organisation"
           labelOnglet="Maturité cyber de votre organisation"
         ></Onglet>
-        <Onglet bind:ongletActif cetOnglet="historique" labelOnglet="Historique"
+        <Onglet
+          bind:ongletActif
+          cetOnglet="historique"
+          labelOnglet="Historique"
+          on:click={reclicHistorique}
         ></Onglet>
         <Onglet
           bind:ongletActif

--- a/front/lib-svelte/src/test-maturite/PropositionRefaireTest.svelte
+++ b/front/lib-svelte/src/test-maturite/PropositionRefaireTest.svelte
@@ -9,8 +9,9 @@
         Vous avez mené un plan d'action cyber et souhaitez mesurer vos progrès ?
         <lab-anssi-lien
           href="/test-maturite"
-          apparence="lien-texte"
+          apparence="lien"
           titre="Refaire le test"
+          taille="md"
         ></lab-anssi-lien>
       </p>
     </div>

--- a/front/lib-svelte/src/test-maturite/ResultatsMonOrganisation.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsMonOrganisation.svelte
@@ -18,6 +18,7 @@
   export let afficheRappelReponses = false;
   export let animeTuiles = true;
   export let dateRealisation: Date | undefined = undefined;
+  export let defilementAutomatique = true;
 
   const calculeIdNiveau = (moyenne: number): IdNiveau => {
     if (moyenne < 1) return 'insuffisant';
@@ -53,7 +54,11 @@
       <div class="date-realisation">Test réalisé le {dateFormatee}</div>
     {/if}
     <h2>Niveau de maturité le plus proche : {niveau.label}</h2>
-    <TuilesMaturite niveauCourant={niveau} {animeTuiles} />
+    <TuilesMaturite
+      niveauCourant={niveau}
+      {animeTuiles}
+      {defilementAutomatique}
+    />
     <div class="description-niveau">
       <h5>{niveau.label}</h5>
       <p>{niveau.description}</p>

--- a/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
@@ -42,6 +42,11 @@
       );
     }
   }
+
+  const afficheHistorique = () => {
+    idResultatTest = undefined;
+    history.pushState(null, '', `${window.location.pathname}#historique`);
+  };
 </script>
 
 <Hero
@@ -52,7 +57,7 @@
 
 <PropositionRefaireTest />
 
-<OngletsTest bind:ongletActif />
+<OngletsTest bind:ongletActif on:reclicHistorique={afficheHistorique} />
 
 {#if ongletActif === 'votre-organisation'}
   <ResultatsMonOrganisation

--- a/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
@@ -14,7 +14,8 @@
   export let affichePubMsc = true;
   export let afficheRappelReponses = false;
   export let animeTuiles = true;
-  export let dateRealisationDernierTest : Date | undefined = undefined;
+  export let dateRealisationDernierTest: Date | undefined = undefined;
+  export let defilementAutomatique = true;
 
   let ongletActif: CleOnglet | undefined;
   let idResultatTest: string | undefined;
@@ -59,6 +60,7 @@
     {affichePubMsc}
     {afficheRappelReponses}
     dateRealisation={dateRealisationDernierTest}
+    {defilementAutomatique}
   />
 {:else if ongletActif === 'historique'}
   <HistoriqueTests {idResultatTest} />

--- a/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
@@ -45,8 +45,8 @@
 </script>
 
 <Hero
-  titre="Résultat de maturité cyber"
-  description="Ce résultat nous permet de vous guider et de vous fournir les informations et les outils essentiels pour agir sur votre maturité cyber."
+  titre="Maturité cyber"
+  description="Testez la maturité cyber de votre organisation, suivez vos progrès et comparez-vous aux autres organisations."
   ariane={$profilStore ? 'Maturité cyber' : 'Tester votre maturité cyber'}
 />
 

--- a/front/lib-svelte/src/test-maturite/TuilesMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/TuilesMaturite.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
   import { afterUpdate } from 'svelte';
-  import { type NiveauMaturite, niveauxMaturite } from '../niveaux-maturite/NiveauxMaturite.donnees';
+  import {
+    type NiveauMaturite,
+    niveauxMaturite,
+  } from '../niveaux-maturite/NiveauxMaturite.donnees';
 
   export let niveauCourant: NiveauMaturite;
   export let animeTuiles = true;
+  export let defilementAutomatique = true;
 
   $: indexNiveauCourant = niveauxMaturite.indexOf(niveauCourant);
 
   const scrolleVersTuileCourante = () => {
     let elementCourant: HTMLDivElement | null = document.querySelector(
-      '.tuile-niveau.courant',
+      '.tuile-niveau.courant'
     );
     elementCourant!.scrollIntoView({ block: 'center' });
   };
@@ -17,7 +21,9 @@
   const estPetitEcran = window.matchMedia('(max-width: 576px)').matches;
   const animation = !estPetitEcran && animeTuiles;
 
-  afterUpdate(scrolleVersTuileCourante);
+  if (defilementAutomatique) {
+    afterUpdate(scrolleVersTuileCourante);
+  }
 </script>
 
 <div class="tuiles-niveau" class:avec-animation={animation}>

--- a/front/lib-svelte/src/ui/ConteneurOnglets.svelte
+++ b/front/lib-svelte/src/ui/ConteneurOnglets.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-
 </script>
 
 <div class="conteneur-scrollable">
@@ -10,6 +9,7 @@
 
 <style>
   .conteneur-onglet {
+    width: min-content;
     margin: 0 0 0 -0.5px;
     display: flex;
     flex-direction: row;

--- a/front/lib-svelte/src/ui/Onglet.svelte
+++ b/front/lib-svelte/src/ui/Onglet.svelte
@@ -1,8 +1,19 @@
 <script lang="ts" generics="T extends string">
+  import { createEventDispatcher } from 'svelte';
+
   export let ongletActif: T;
   export let cetOnglet: T;
   export let labelOnglet: string;
   export let sansBordureEnBas: boolean = false;
+
+  const emet = createEventDispatcher<{
+    click: null;
+  }>();
+
+  const clic = () => {
+    emet('click');
+    ongletActif = cetOnglet;
+  };
 </script>
 
 <button
@@ -10,7 +21,7 @@
   class="onglet"
   class:active={ongletActif === cetOnglet}
   class:sansBordureEnBas
-  on:click={() => (ongletActif = cetOnglet)}
+  on:click={clic}
 >
   <span class="label">{labelOnglet}</span>
 </button>


### PR DESCRIPTION
- Change le wording du bandeau
- Supprime l'auto-scroll lors du clic sur l'onglet  "maturité cyber de votre organisation"
- Clic sur l'onglet historique depuis le détail d'un test ramène sur l'historique
- Conserver la bordure de l’onglet dans une résolution inférieure à 458px
- Corrige le style du lien "Refaire le test"