### PR TITLE
Évalue la condition de façon réactive

### DIFF
--- a/front/lib-svelte/src/test-maturite/TestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/TestMaturite.svelte
@@ -91,11 +91,12 @@
     introFaite = true;
   }
 
-  function doitMontrerPropositions() {
+  let montreProposition = false;
+  $: {
     const avecPropositions = etapesTestMaturite.filter(
       (q) => q.propositions.length > 0
     );
-    return $questionnaireStore.questionCourante < avecPropositions.length;
+    montreProposition = $questionnaireStore.questionCourante < avecPropositions.length;
   }
 
   let ongletActif: 'votre-organisation' | 'comparaison' = 'votre-organisation';
@@ -175,7 +176,7 @@
                   .question}
               </h2>
 
-              {#if doitMontrerPropositions()}
+              {#if montreProposition}
                 <div class="propositions">
                   {#each etapesTestMaturite[$questionnaireStore.questionCourante].propositions as proposition, index (proposition)}
                     <label>


### PR DESCRIPTION
On a remarqué qu'en version `5.36` de Svelte, la condition n'était pas évaluée de façon réactive...
Pour éviter les mauvaises surprises lors de prochaines mises à jour de Svelte, on s'assure que cette condition fonctionne maintenant, et avec la dernière version (du moment).