### PR TITLE
Ignore les erreurs Axios `Request aborted`

### DIFF
--- a/front/scripts/sentry.js
+++ b/front/scripts/sentry.js
@@ -2,9 +2,21 @@ const dsn = document.getElementById('script-sentry').dataset.dsn;
 const environment =
   document.getElementById('script-sentry').dataset.environnement;
 
+// Voir l'issue https://github.com/axios/axios/issues/6209#issuecomment-2299747509
+const avantEnvoiSentry = (evenement, detail) => {
+  if (
+    axios?.isAxiosError(detail?.originalException) &&
+    detail?.originalException?.code === 'ECONNABORTED'
+  ) {
+    return null;
+  }
+  return evenement;
+};
+
 Sentry.init({
   dsn,
   environment,
+  beforeSend: avantEnvoiSentry,
 });
 
 Sentry.setTag('msc-source', 'frontend');


### PR DESCRIPTION
...car elles correspondent à un rafraîchissement du navigateur par l’utilisateur, ce qui n’est pas une erreur pour nous