### PR TITLE
[BUG] Corrige le problème `Axios is not defined`

### DIFF
--- a/front/scripts/sentry.js
+++ b/front/scripts/sentry.js
@@ -5,7 +5,6 @@ const environment =
 // Voir l'issue https://github.com/axios/axios/issues/6209#issuecomment-2299747509
 const avantEnvoiSentry = (evenement, detail) => {
   if (
-    axios?.isAxiosError(detail?.originalException) &&
     detail?.originalException?.code === 'ECONNABORTED'
   ) {
     return null;


### PR DESCRIPTION
...car nous n’avons pas axios dans nos dépendances du front, uniquement dans le contexte de svelte, où il est intégré au paquet grâce à vite. Plutôt que de rajouter une dépendance peu utile et contraignante vers axios, nous préférons donc ne pas vérifier qu’il s’agit d’une erreur axios (après tout, si c’était une erreur fetch nous voudrions également l’ignorer) et nous baser uniquement sur le code de l’exception d’origine qui est suffisamment explicite (`ECONNABORTED`) pour nous permettre d’ignorer l’erreur.