### PR TITLE
Bénéficie des sous-titres

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -30,7 +30,7 @@
     "vitest": "^3.0.5"
   },
   "dependencies": {
-    "@lab-anssi/lib": "^2.0.0",
+    "@lab-anssi/lib": "^2.1.2",
     "@sentry/node": "^7.102.1",
     "@types/bcrypt": "^5.0.2",
     "axios": "^1.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "name": "anssi-portail-back",
       "version": "1.0.0",
       "dependencies": {
-        "@lab-anssi/lib": "^2.0.0",
+        "@lab-anssi/lib": "^2.1.2",
         "@sentry/node": "^7.102.1",
         "@types/bcrypt": "^5.0.2",
         "axios": "^1.8.2",
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@lab-anssi/lib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@lab-anssi/lib/-/lib-2.0.0.tgz",
-      "integrity": "sha512-srDfkh+2YpbdePpZOZCb+1/VKIjns3fQLDjxcti5+cy9oxSWV1fq7SFaAREDUPqQfdEkKb/GuWGoemXHziVJeg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lab-anssi/lib/-/lib-2.1.2.tgz",
+      "integrity": "sha512-QPr9ouI88QtQMnHa4rVbhq58hYKKO9fSCL4yhCbGodi/Y23jZfiM8GWfc7RpLqvaa8jcYrN4kiqMXupmWd8awA==",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.9.0",


### PR DESCRIPTION
...en se branchant sur la dernière version de la bibliothèque du lab qui les ajoute aux vidéos dans les pages venant de Crisp.

<img width="900" height="725" alt="image" src="https://github.com/user-attachments/assets/eff9c58a-5797-4d0e-af97-ef5696a4b10a" />
