### PR TITLE
[MODALE SORTIE] Aseptise les retours expériences

### DIFF
--- a/back/src/infra/markdown.ts
+++ b/back/src/infra/markdown.ts
@@ -1,0 +1,24 @@
+export const aseptiseMarkdown = (message: string) =>
+  [
+    '\\',
+    '!',
+    '[',
+    ']',
+    '`',
+    '{',
+    '}',
+    '*',
+    '_',
+    '<',
+    '>',
+    '(',
+    ')',
+    '#',
+    '+',
+    '-',
+    '.',
+    '|',
+  ].reduce(
+    (acc, caractere) => acc.replaceAll(caractere, `\\${caractere}`),
+    message
+  );

--- a/back/src/infra/messagerieMattermost.ts
+++ b/back/src/infra/messagerieMattermost.ts
@@ -3,6 +3,7 @@ import {
   RetourExperience,
 } from '../metier/messagerieInstantanee';
 import axios from 'axios';
+import { aseptiseMarkdown } from './markdown';
 
 export const messagerieMattermost = (): MessagerieInstantanee => ({
   notifieUnRetourExperience: async (retourExperience: RetourExperience) => {
@@ -11,7 +12,7 @@ export const messagerieMattermost = (): MessagerieInstantanee => ({
       const message = `### Retour utilisateur
 Un utilisateur a laissé un retour d’expérience suite à la non-complétion du formulaire de demande d’aide
 Raison : ${retourExperience.raison}
-Précision : ${retourExperience.precision}
+Précision : ${aseptiseMarkdown(retourExperience.precision ?? '')}
 Email de contact : ${retourExperience.emailDeContact}`;
 
       await axios.post(urlWebhook, { text: message });

--- a/back/tests/infra/markdown.spec.ts
+++ b/back/tests/infra/markdown.spec.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { aseptiseMarkdown } from '../../src/infra/markdown';
+
+describe('Le markdown', () => {
+  it("retourne la chaîne intacte lorsqu'elle ne contient aucun caractère spécial", () => {
+    const markdown = aseptiseMarkdown('bonjour tout le monde');
+
+    assert.equal('bonjour tout le monde', markdown);
+  });
+
+  [
+    '!',
+    '\\',
+    '[',
+    ']',
+    '`',
+    '{',
+    '}',
+    '*',
+    '_',
+    '<',
+    '>',
+    '(',
+    ')',
+    '#',
+    '+',
+    '-',
+    '.',
+    '|',
+  ].forEach((caractereAEchapper) =>
+    it(`échappe les ${caractereAEchapper}`, () => {
+      const markdown = aseptiseMarkdown(caractereAEchapper);
+
+      assert.equal(`\\${caractereAEchapper}`, markdown);
+    })
+  );
+});


### PR DESCRIPTION
Le contenu de la modale de retour expérience est envoyé sur mattermost qui interprète le message au format markdown. Le champ précision est libre et il est donc possible d’envoyer des messages contenant du formatage et des images non désirables sur mattermost. Nous aseptisons donc ce champ pour éviter tout souci. 