### PR TITLE
[CORRECTION] Force l'envoi à null dans la création de test

### DIFF
--- a/front/lib-svelte/src/test-maturite/TestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/TestMaturite.svelte
@@ -68,9 +68,9 @@
   async function obtiensResultat() {
     const reponse = await axios.post<CreationTest>('/api/resultats-test', {
       reponses: $resultatsQuestionnaire,
-      secteur,
-      region,
-      tailleOrganisation,
+      secteur: secteur ? secteur : null,
+      region: region ? region : null,
+      tailleOrganisation: tailleOrganisation ? tailleOrganisation : null,
       codeSessionGroupe,
     });
     const { id } = reponse.data;


### PR DESCRIPTION
...la chaine vide n'étant une valeur valide