### PR TITLE
ajout du lien vers secnumacademie

### DIFF
--- a/front/_services/secnum-academie.md
+++ b/front/_services/secnum-academie.md
@@ -5,6 +5,7 @@ nom: SecNumAcadémie
 titreHtml: SecNumAcadémie
 avecFicheDetaillee: true
 description: "Se former avec le MOOC de l'ANSSI"
+lien: https://secnumacademie.gouv.fr/
 illustration: secnumacademie/secnum-academie.png
 sources:
   - ANSSI


### PR DESCRIPTION
Cette pauvre petite fiche pour SecNumAcadémie n'avait pas de lien - c'est désormais le cas