### PR TITLE
corrige une coquille dans un email COT

### DIFF
--- a/front/lib-svelte/src/contacts/contacts.donnees.ts
+++ b/front/lib-svelte/src/contacts/contacts.donnees.ts
@@ -4,7 +4,7 @@ export const contactsParRegion: Record<CodeRegion, Contacts> = {
   'FR-ARA': {
     COT: {
       nom: 'Mathieu DELAPLACE / Marianne DELARUE',
-      email: 'auvergne-rhone-alpes[@ssi.gouv.fr',
+      email: 'auvergne-rhone-alpes@ssi.gouv.fr',
     },
   },
   'FR-BFC': {


### PR DESCRIPTION
Il y avait un crochet qui se baladait dans une adresse mail