### PR TITLE
Ajoute un formulaire de test pour Matomo

### DIFF
--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -136,9 +136,17 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
     'financements',
     'prestataires-labellises',
     'contacts',
+    "formulaire-matomo"
   ].forEach((page) =>
     app.use(`/${page}`, ressourcePagesJekyll(configurationServeur, page))
   );
+
+  app.post('/formulaire-matomo', (_requete: Request, reponse: Response) => {
+    reponse
+      .contentType('text/html')
+      .status(200)
+      .sendFileAvecNonce(fournisseurChemin.cheminPageJekyll("formulaire-matomo"));
+  });
 
   app.use(
     '/favoris-partages/:id',

--- a/front/formulaire-matomo.html
+++ b/front/formulaire-matomo.html
@@ -1,0 +1,18 @@
+---
+layout: accueil
+titreHtml: 'Accueil | MesServicesCyber'
+permalink: /formulaire-matomo/
+---
+
+<script>
+
+</script>
+
+<section>
+  <div class="contenu-section">
+    <form id="test" method="post" action="/formulaire-matomo" name="test">
+      <input type="text" value="Formulaire" name="entree">
+      <button type="submit">GO</button>
+    </form>
+  </div>
+</section>


### PR DESCRIPTION
Pour explorer le fonctionnement de Matomo, nous ajoutons un formulaire qui permettra de vérifier que les données ne sont pas captées par Matomo.