### PR TITLE
Évite les erreurs 401

### DIFF
--- a/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
@@ -68,8 +68,8 @@
     dateRealisation={dateRealisationDernierTest}
     {defilementAutomatique}
   />
-{:else if ongletActif === 'historique'}
+{:else if ongletActif === 'historique' && $profilStore}
   <HistoriqueTests {idResultatTest} />
-{:else}
+{:else if $profilStore}
   <ComparaisonTest testRealise={true} {featureFlagFiltresComparaison} />
 {/if}


### PR DESCRIPTION
...Le composant ComparaisonTest était chargé car l’onglet actif n’a pas de valeur par défaut. Le montage de ce composant provoque une lecture du dernier test de maturité, ce qui n’est pas autorisé pour un utilisateur non connecté. En évitant de charger ce composant, on évite ainsi une erreur non gérée. Par mesure de précaution, on évite également le chargement des composants liés aux onglets `Historique` et `Comparaison` si l’utilisateur modifie le fragement de l’url qui permet de "changer d’onglet".