### PR TITLE
Évite de couper les cartes

### DIFF
--- a/front/assets/styles/test-maturite.scss
+++ b/front/assets/styles/test-maturite.scss
@@ -270,7 +270,9 @@ section {
     overflow-x: auto;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
-    justify-content: center;
+    @include a-partir-de(sm) {
+      justify-content: center;
+    }
 
     .carte {
       flex: 0 0 282px;
@@ -446,4 +448,3 @@ section {
     }
   }
 }
-


### PR DESCRIPTION
...dans l'encart promotionnel de l'espace connecté. Pour cela on ne centre les cartes qu'à partir de 576px de large, sinon le centrage implique un découpage de la carte de gauche vers laquelle il n'est pas possible de scroller

Avant :
<img width="1076" height="1954" alt="image" src="https://github.com/user-attachments/assets/85b708e2-63fa-4eee-9df3-31d7ae4d9481" />

Après : 
<img width="353" height="778" alt="image" src="https://github.com/user-attachments/assets/86737c8e-baad-41e1-8a8c-d4bc3aa68c54" />
