### PR TITLE
[GUIDES] Signale explicitement l'absence d'un guide

### DIFF
--- a/front/lib-svelte/src/catalogue/guides/Guide.svelte
+++ b/front/lib-svelte/src/catalogue/guides/Guide.svelte
@@ -144,6 +144,14 @@
       </div>
     </div>
   </div>
+{:else}
+  <dsfr-container>
+    <div class="non-trouve">
+      <h1>Guide introuvable</h1>
+      <p>Le guide demandé n’a pas pu être trouvé.</p>
+      <img src="/assets/images/illustration-dragon-aucun-resultat.svg" alt="Guide introuvable" />
+    </div>
+  </dsfr-container>
 {/if}
 
 <style lang="scss">
@@ -414,5 +422,11 @@
         margin-left: auto;
       }
     }
+  }
+
+  .non-trouve {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 </style>


### PR DESCRIPTION
<img width="1174" height="351" alt="image" src="https://github.com/user-attachments/assets/e90816a7-186c-431c-abe4-e2a63b6d5e83" />
