### PR TITLE
[SOIN] Supprime la fonction d'aseptisation du middleware

### DIFF
--- a/back/src/api/favoris/ressourceFavori.ts
+++ b/back/src/api/favoris/ressourceFavori.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { decode } from 'html-entities';
 import { MiseAJourFavorisUtilisateur } from '../../bus/miseAJourFavorisUtilisateur';
 import { ConfigurationServeur } from '../configurationServeur';
 import { filetRouteAsynchrone } from '../middleware';
@@ -18,8 +19,7 @@ const ressourceFavori = ({
     middleware.ajouteUtilisateurARequete(entrepotUtilisateur, adaptateurHachage),
     middleware.aseptise('id'),
     filetRouteAsynchrone(async (requete, reponse) => {
-      let id = requete.params.id as string;
-      id = id.replaceAll('&#x2F;', '/');
+      const id = decode(requete.params.id as string);
       const utilisateur = requete.utilisateur;
       await entrepotFavori.retire({ idItemCyber: id, utilisateur });
 

--- a/back/src/api/favoris/ressourceFavori.ts
+++ b/back/src/api/favoris/ressourceFavori.ts
@@ -1,5 +1,4 @@
 import { Router } from 'express';
-import { decode } from 'html-entities';
 import { MiseAJourFavorisUtilisateur } from '../../bus/miseAJourFavorisUtilisateur';
 import { ConfigurationServeur } from '../configurationServeur';
 import { filetRouteAsynchrone } from '../middleware';
@@ -17,9 +16,8 @@ const ressourceFavori = ({
     '/:id',
     middleware.verifieJWT,
     middleware.ajouteUtilisateurARequete(entrepotUtilisateur, adaptateurHachage),
-    middleware.aseptise('id'),
     filetRouteAsynchrone(async (requete, reponse) => {
-      const id = decode(requete.params.id as string);
+      const id = requete.params.id as string;
       const utilisateur = requete.utilisateur;
       await entrepotFavori.retire({ idItemCyber: id, utilisateur });
 

--- a/back/src/api/favoris/ressourceFavoris.ts
+++ b/back/src/api/favoris/ressourceFavoris.ts
@@ -1,7 +1,8 @@
-import { ConfigurationServeur } from '../configurationServeur';
 import { Request, Response, Router } from 'express';
 import { check } from 'express-validator';
+import { decode } from 'html-entities';
 import { MiseAJourFavorisUtilisateur } from '../../bus/miseAJourFavorisUtilisateur';
+import { ConfigurationServeur } from '../configurationServeur';
 import { filetRouteAsynchrone } from '../middleware';
 
 const ressourceFavoris = ({
@@ -21,8 +22,7 @@ const ressourceFavoris = ({
     [check('idItemCyber').not().isEmpty().withMessage("L'idItemCyber est invalide")],
     middleware.valide(),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
-      let idItemCyber = requete.body.idItemCyber;
-      idItemCyber = idItemCyber.replaceAll('&#x2F;', '/');
+      const idItemCyber = decode(requete.body.idItemCyber);
       const utilisateur = requete.utilisateur;
       await entrepotFavori.ajoute({
         idItemCyber,

--- a/back/src/api/favoris/ressourceFavoris.ts
+++ b/back/src/api/favoris/ressourceFavoris.ts
@@ -1,6 +1,5 @@
 import { Request, Response, Router } from 'express';
 import { check } from 'express-validator';
-import { decode } from 'html-entities';
 import { MiseAJourFavorisUtilisateur } from '../../bus/miseAJourFavorisUtilisateur';
 import { ConfigurationServeur } from '../configurationServeur';
 import { filetRouteAsynchrone } from '../middleware';
@@ -17,12 +16,11 @@ const ressourceFavoris = ({
   routeur.post(
     '/',
     middleware.verifieJWT,
-    middleware.aseptise('idItemCyber'),
     middleware.ajouteUtilisateurARequete(entrepotUtilisateur, adaptateurHachage),
     [check('idItemCyber').not().isEmpty().withMessage("L'idItemCyber est invalide")],
     middleware.valide(),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
-      const idItemCyber = decode(requete.body.idItemCyber);
+      const idItemCyber = requete.body.idItemCyber as string;
       const utilisateur = requete.utilisateur;
       await entrepotFavori.ajoute({
         idItemCyber,

--- a/back/src/api/middleware.ts
+++ b/back/src/api/middleware.ts
@@ -1,6 +1,6 @@
 import { HttpStatusCode } from 'axios';
 import { NextFunction, Request, RequestHandler, Response } from 'express';
-import { check, validationResult } from 'express-validator';
+import { validationResult } from 'express-validator';
 import helmet from 'helmet';
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
@@ -14,7 +14,6 @@ import { FournisseurChemin } from './fournisseurChemin';
 type FonctionMiddleware = (requete: Request, reponse: Response, suite: NextFunction) => Promise<void>;
 
 export type Middleware = {
-  aseptise: (...nomsParametres: string[]) => FonctionMiddleware;
   valide: () => FonctionMiddleware;
   interdisLaMiseEnCache: FonctionMiddleware;
   verifieJWT: FonctionMiddleware;
@@ -37,14 +36,6 @@ export const fabriqueMiddleware = ({
   fournisseurChemin: FournisseurChemin;
   adaptateurEnvironnement: AdaptateurEnvironnement;
 }): Middleware => {
-  const aseptise =
-    (...nomsParametres: string[]) =>
-    async (requete: Request, _reponse: Response, suite: NextFunction) => {
-      const aseptisations = nomsParametres.map((p) => check(p).trim().escape().run(requete));
-      await Promise.all(aseptisations);
-      suite();
-    };
-
   const valide = () => async (requete: Request, reponse: Response, suite: NextFunction) => {
     const erreurs = validationResult(requete);
     if (!erreurs.isEmpty()) {
@@ -183,7 +174,6 @@ export const fabriqueMiddleware = ({
   };
 
   return {
-    aseptise,
     valide,
     verifieJWT,
     verifieJWTNavigation,

--- a/back/src/api/mon-aide-cyber/ressourceDemandesAide.ts
+++ b/back/src/api/mon-aide-cyber/ressourceDemandesAide.ts
@@ -1,10 +1,11 @@
 import cors from 'cors';
 import { Router } from 'express';
 import { body, check } from 'express-validator';
+import { encode } from 'html-entities';
 import { codeDepartement } from '../../metier/referentielDepartements';
 import { ConfigurationServeur } from '../configurationServeur';
-import CorpsDeRequeteTypee = Express.CorpsDeRequeteTypee;
 import { filetRouteAsynchrone } from '../middleware';
+import CorpsDeRequeteTypee = Express.CorpsDeRequeteTypee;
 
 export type CorpsDemandeAide = {
   origine?: string;
@@ -27,13 +28,6 @@ const ressourceDemandesAide = ({ adaptateurMonAideCyber, middleware }: Configura
   routeur.post(
     '/',
     cors(),
-    middleware.aseptise(
-      'entiteAidee.email',
-      'entiteAidee.departement',
-      'entiteAidee.raisonSociale',
-      'emailAidant',
-      'identifiantAidant'
-    ),
     check('entiteAidee.departement')
       .isString()
       .isIn(codeDepartement)
@@ -68,17 +62,18 @@ const ressourceDemandesAide = ({ adaptateurMonAideCyber, middleware }: Configura
       try {
         const { emailAidant, identifiantAidant, siretAidant, entiteAidee, origine } = requete.body;
         const { email, departement, raisonSociale, siret } = entiteAidee;
+        // suite à la suppression de l'aseptisation, on force un encodage pour garder des données consistantes envoyées à Mon Aide Cyber
         await adaptateurMonAideCyber.creeDemandeAide({
           ...(origine && { origine }),
           aidant: {
-            ...(emailAidant && { email: emailAidant }),
+            ...(emailAidant && { email: encode(emailAidant) }),
             ...(identifiantAidant && { identifiant: identifiantAidant }),
             ...(siretAidant && { siret: siretAidant }),
           },
           entiteAidee: {
-            email,
+            email: encode(email),
             departement,
-            raisonSociale,
+            raisonSociale: encode(raisonSociale),
             siret,
           },
         });

--- a/back/src/api/ressourceAnnuaireOrganisations.ts
+++ b/back/src/api/ressourceAnnuaireOrganisations.ts
@@ -4,15 +4,11 @@ import { CodeDepartement, estCodeDepartement } from '../metier/referentielDepart
 import { ConfigurationServeur } from './configurationServeur';
 import { filetRouteAsynchrone } from './middleware';
 
-const ressourceAnnuaireOrganisations = ({
-  middleware,
-  adaptateurRechercheEntreprise,
-}: ConfigurationServeur): Router => {
+const ressourceAnnuaireOrganisations = ({ adaptateurRechercheEntreprise }: ConfigurationServeur): Router => {
   const routeur = Router();
   routeur.get(
     '/',
     cors(),
-    middleware.aseptise('recherche', 'departement'),
     filetRouteAsynchrone(async (requete, reponse) => {
       const recherche = requete.query.recherche ? requete.query.recherche.toString() : '';
       const departement = requete.query.departement ? requete.query.departement.toString() : null;

--- a/back/src/api/ressourceAvisUtilisateur.ts
+++ b/back/src/api/ressourceAvisUtilisateur.ts
@@ -19,7 +19,6 @@ export const ressourceAvisUtilisateur = ({
       check('emailDeContact').optional({ values: 'falsy' }).isEmail().withMessage("L'email est invalide"),
     ],
     middleware.valide(),
-    middleware.aseptise('commentaire'),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
       const { niveauDeSatisfaction, commentaire, emailDeContact } = requete.body as AvisUtilisateur;
       await messagerieInstantanee.notifieUnAvisUtilisateur({

--- a/back/src/api/ressourcePageCrisp.ts
+++ b/back/src/api/ressourcePageCrisp.ts
@@ -1,12 +1,11 @@
-import { ConfigurationServeur } from './configurationServeur';
 import { Request, Response, Router } from 'express';
+import { ConfigurationServeur } from './configurationServeur';
 import { filetRouteAsynchrone } from './middleware';
 
-const ressourcePageCrisp = ({ cmsCrisp, adaptateurEnvironnement, middleware }: ConfigurationServeur) => {
+const ressourcePageCrisp = ({ cmsCrisp, adaptateurEnvironnement }: ConfigurationServeur) => {
   const routeur = Router();
   routeur.get(
     '/:id',
-    middleware.aseptise('id'),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
       const idArticle = adaptateurEnvironnement.crisp().idArticle((requete.params.id as string).toUpperCase());
       if (!idArticle) {

--- a/back/src/api/ressourcePageProduit.ts
+++ b/back/src/api/ressourcePageProduit.ts
@@ -2,13 +2,10 @@ import { HttpStatusCode } from 'axios';
 import { Request, Response, Router } from 'express';
 import { ConfigurationServeur } from './configurationServeur';
 
-const ressourcePageProduit = (
-  { fournisseurChemin, middleware }: ConfigurationServeur,
-  repertoireProduits: string
-): Router => {
+const ressourcePageProduit = ({ fournisseurChemin }: ConfigurationServeur, repertoireProduits: string): Router => {
   const routeur = Router();
 
-  routeur.get('/:id', middleware.aseptise('id'), (requete: Request, reponse: Response) => {
+  routeur.get('/:id', (requete: Request, reponse: Response) => {
     if (requete.params.id === 'mon-espace-nis2.html') {
       return reponse.redirect(HttpStatusCode.MovedPermanently, '/nis2');
     }

--- a/back/src/api/ressourceProfil.ts
+++ b/back/src/api/ressourceProfil.ts
@@ -1,7 +1,8 @@
 import { Request, Response, Router } from 'express';
+import { decode } from 'html-entities';
+import { estCodeDepartement, regionDuDepartement } from '../metier/referentielDepartements';
 import { Organisation } from '../metier/utilisateur';
 import { ConfigurationServeur } from './configurationServeur';
-import { estCodeDepartement, regionDuDepartement } from '../metier/referentielDepartements';
 import { filetRouteAsynchrone } from './middleware';
 
 const ressourceProfil = ({
@@ -31,7 +32,7 @@ const ressourceProfil = ({
           email: utilisateurConnecte?.email,
           nom: utilisateurConnecte?.nom,
           prenom: utilisateurConnecte?.prenom,
-          siret: organisation?.siret,
+          siret: decode(organisation?.siret),
           estAgentAnssi: await utilisateurConnecte?.estAgentAnssi(),
           idListeFavoris: utilisateurConnecte?.idListeFavoris,
           codeDepartement,

--- a/back/src/api/ressourceRetoursExperience.ts
+++ b/back/src/api/ressourceRetoursExperience.ts
@@ -1,7 +1,7 @@
 import { Request, Response, Router } from 'express';
-import { ConfigurationServeur } from './configurationServeur';
 import { check } from 'express-validator';
 import { RetourExperienceDonne } from '../bus/evenements/retourExperienceDonne';
+import { ConfigurationServeur } from './configurationServeur';
 import { filetRouteAsynchrone } from './middleware';
 
 export const ressourceRetoursExperience = ({
@@ -19,7 +19,6 @@ export const ressourceRetoursExperience = ({
       check('emailDeContact').optional({ values: 'falsy' }).isEmail().withMessage("L'email est invalide"),
     ],
     middleware.valide(),
-    middleware.aseptise('precision'),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
       const { raison, emailDeContact, precision } = requete.body;
       await messagerieInstantanee.notifieUnRetourExperience({

--- a/back/src/api/ressourceUtilisateurs.ts
+++ b/back/src/api/ressourceUtilisateurs.ts
@@ -1,8 +1,9 @@
 import { Request, Response, Router } from 'express';
-import { ConfigurationServeur } from './configurationServeur';
 import { check } from 'express-validator';
+import { encode } from 'html-entities';
 import { CompteCree } from '../bus/evenements/compteCree';
 import { Utilisateur } from '../metier/utilisateur';
+import { ConfigurationServeur } from './configurationServeur';
 import { filetRouteAsynchrone } from './middleware';
 
 const ressourceUtilisateurs = ({
@@ -15,7 +16,6 @@ const ressourceUtilisateurs = ({
   const routeur = Router();
   routeur.post(
     '/',
-    middleware.aseptise('telephone', 'domainesSpecialite.*', 'siretEntite'),
     [
       check('token').not().isEmpty().withMessage('Le token est invalide'),
       check('telephone')
@@ -52,7 +52,11 @@ const ressourceUtilisateurs = ({
 
         await entrepotUtilisateur.ajoute(utilisateur);
 
-        await busEvenements.publie(new CompteCree({ email, prenom, nom, infoLettre: infolettreAcceptee, telephone }));
+        // suite à la suppression de l'aseptisation, on force un encodage pour garder des données consistantes dans la base de données Journal
+        const telephoneEncode = encode(telephone);
+        await busEvenements.publie(
+          new CompteCree({ email, prenom, nom, infoLettre: infolettreAcceptee, telephone: telephoneEncode })
+        );
 
         reponse.sendStatus(201);
       } catch {

--- a/back/src/api/testMaturite/ressourceRepartitionDesResultatsDeTest.ts
+++ b/back/src/api/testMaturite/ressourceRepartitionDesResultatsDeTest.ts
@@ -9,12 +9,10 @@ import { filetRouteAsynchrone } from '../middleware';
 export const ressourceRepartitionDesResultatsDeTest = ({
   entrepotResultatTest,
   adaptateurEnvironnement,
-  middleware,
 }: ConfigurationServeur) => {
   const routeur = Router();
   routeur.get(
     '/',
-    middleware.aseptise('secteur', 'tailleOrganisation', 'region'),
     filetRouteAsynchrone(
       async (
         requete: Request<unknown, unknown, unknown, { secteur?: string; tailleOrganisation?: string; region?: string }>,

--- a/back/src/api/testMaturite/ressourceResultatsDeTest.ts
+++ b/back/src/api/testMaturite/ressourceResultatsDeTest.ts
@@ -57,7 +57,6 @@ const ressourceResultatsDeTest = ({
     ],
     middleware.valide(),
     middleware.ajouteUtilisateurARequete(entrepotUtilisateur, adaptateurHachage),
-    middleware.aseptise('codeSessionGroupe'),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
       const { tailleOrganisation, region, secteur, reponses, codeSessionGroupe } = requete.body;
 

--- a/back/src/api/testMaturite/ressourceResultatsSessionDeGroupe.ts
+++ b/back/src/api/testMaturite/ressourceResultatsSessionDeGroupe.ts
@@ -4,13 +4,11 @@ import { filetRouteAsynchrone } from '../middleware';
 
 export const ressourceResultatsSessionDeGroupe = ({
   entrepotSessionDeGroupe,
-  middleware,
   entrepotResultatTest,
 }: ConfigurationServeur) => {
   const routeur = Router();
   routeur.get(
     '/:code/resultats',
-    middleware.aseptise('code'),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
       const session = await entrepotSessionDeGroupe.parCode(requete.params.code as string);
       if (!session) {

--- a/back/src/api/testMaturite/ressourceSessionDeGroupe.ts
+++ b/back/src/api/testMaturite/ressourceSessionDeGroupe.ts
@@ -2,11 +2,10 @@ import { Request, Response, Router } from 'express';
 import { ConfigurationServeur } from '../configurationServeur';
 import { filetRouteAsynchrone } from '../middleware';
 
-export const ressourceSessionDeGroupe = ({ entrepotSessionDeGroupe, middleware }: ConfigurationServeur) => {
+export const ressourceSessionDeGroupe = ({ entrepotSessionDeGroupe }: ConfigurationServeur) => {
   const routeur = Router();
   routeur.get(
     '/:code',
-    middleware.aseptise('code'),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
       const session = await entrepotSessionDeGroupe.parCode(requete.params.code as string);
       reponse.sendStatus(session ? 200 : 404);

--- a/back/src/infra/adaptateurMonAideCyber.ts
+++ b/back/src/infra/adaptateurMonAideCyber.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
+import { AdaptateurEnvironnement } from './adaptateurEnvironnement';
 import { adaptateurMonAideCyberVide } from './adaptateurMonAideCyberVide';
 import { Cache } from './cache';
-import { AdaptateurEnvironnement } from './adaptateurEnvironnement';
 
 export type DemandeAide = {
   origine?: string;

--- a/back/src/infra/adaptateurProfilAnssi.ts
+++ b/back/src/infra/adaptateurProfilAnssi.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { decode } from 'html-entities';
 import { adaptateurProfilAnssiVide } from './adaptateurProfilAnssiVide';
 
 const CONFIGURATION_AUTHENTIFICATION = {
@@ -48,7 +49,9 @@ const adaptateurProfilAnssi = (): AdaptateurProfilAnssi => {
     const urlProfil = `${process.env.PROFIL_ANSSI_URL_BASE}/profil/${email}`;
     try {
       const reponse = await axios.get(urlProfil, CONFIGURATION_AUTHENTIFICATION);
-      return reponse.data;
+      return JSON.parse(
+        JSON.stringify(reponse.data, (_cle, valeur) => (typeof valeur === 'string' ? decode(valeur) : valeur))
+      );
     } catch (e) {
       if (axios.isAxiosError(e) && e.response?.status !== 404) {
         console.error({

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -184,9 +184,6 @@ export const fauxMiddleware: Middleware = {
   positionneLesCsp: () => async (_, __, suite) => {
     suite();
   },
-  aseptise: () => async (_, __, suite) => {
-    suite();
-  },
   valide: () => async (_, __, suite) => {
     suite();
   },

--- a/back/tests/api/favoris/ressourceFavori.spec.ts
+++ b/back/tests/api/favoris/ressourceFavori.spec.ts
@@ -1,7 +1,14 @@
+import { Express } from 'express';
+import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
 import request from 'supertest';
-import { Express } from 'express';
+import { fabriqueMiddleware } from '../../../src/api/middleware';
 import { creeServeur } from '../../../src/api/msc';
+import { MiseAJourFavorisUtilisateur } from '../../../src/bus/miseAJourFavorisUtilisateur';
+import { fabriqueBusPourLesTests, MockBusEvenement } from '../../bus/busPourLesTests';
+import { EntrepotFavoriMemoire } from '../../persistance/entrepotFavoriMemoire';
+import { EntrepotUtilisateurMemoire } from '../../persistance/entrepotUtilisateurMemoire';
+import { encodeSession } from '../cookie';
 import {
   configurationDeTestDuServeur,
   fauxAdaptateurEnvironnement,
@@ -9,13 +16,6 @@ import {
   fauxFournisseurDeChemin,
   fauxMiddleware,
 } from '../fauxObjets';
-import assert from 'node:assert';
-import { EntrepotFavoriMemoire } from '../../persistance/entrepotFavoriMemoire';
-import { encodeSession } from '../cookie';
-import { fabriqueMiddleware } from '../../../src/api/middleware';
-import { fabriqueBusPourLesTests, MockBusEvenement } from '../../bus/busPourLesTests';
-import { MiseAJourFavorisUtilisateur } from '../../../src/bus/miseAJourFavorisUtilisateur';
-import { EntrepotUtilisateurMemoire } from '../../persistance/entrepotUtilisateurMemoire';
 import { jeanneDupont } from '../objetsPretsALEmploi';
 
 describe('La ressource des services et ressources favoris', () => {
@@ -79,18 +79,6 @@ describe('La ressource des services et ressources favoris', () => {
         .set('Cookie', [cookieJeanneDupont]);
 
       assert.equal(reponse.statusCode, 200);
-      const favoris = await entrepotFavori.tousCeuxDeUtilisateur(jeanneDupont);
-      assert.equal(favoris.length, 0);
-    });
-
-    it('aseptise le paramètre id', async () => {
-      await entrepotFavori.ajoute({
-        idItemCyber: 'unId&lt;truc',
-        utilisateur: jeanneDupont,
-      });
-
-      await request(serveur).delete(`/api/favoris/unId<truc`).set('Cookie', [cookieJeanneDupont]);
-
       const favoris = await entrepotFavori.tousCeuxDeUtilisateur(jeanneDupont);
       assert.equal(favoris.length, 0);
     });

--- a/back/tests/api/favoris/ressourceFavoris.spec.ts
+++ b/back/tests/api/favoris/ressourceFavoris.spec.ts
@@ -1,7 +1,14 @@
+import { Express } from 'express';
+import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
 import request from 'supertest';
-import { Express } from 'express';
+import { fabriqueMiddleware } from '../../../src/api/middleware';
 import { creeServeur } from '../../../src/api/msc';
+import { MiseAJourFavorisUtilisateur } from '../../../src/bus/miseAJourFavorisUtilisateur';
+import { fabriqueBusPourLesTests, MockBusEvenement } from '../../bus/busPourLesTests';
+import { EntrepotFavoriMemoire } from '../../persistance/entrepotFavoriMemoire';
+import { EntrepotUtilisateurMemoire } from '../../persistance/entrepotUtilisateurMemoire';
+import { encodeSession } from '../cookie';
 import {
   configurationDeTestDuServeur,
   fauxAdaptateurEnvironnement,
@@ -9,14 +16,7 @@ import {
   fauxFournisseurDeChemin,
   fauxMiddleware,
 } from '../fauxObjets';
-import assert from 'node:assert';
-import { EntrepotFavoriMemoire } from '../../persistance/entrepotFavoriMemoire';
-import { encodeSession } from '../cookie';
-import { fabriqueMiddleware } from '../../../src/api/middleware';
-import { MiseAJourFavorisUtilisateur } from '../../../src/bus/miseAJourFavorisUtilisateur';
-import { fabriqueBusPourLesTests, MockBusEvenement } from '../../bus/busPourLesTests';
 import { hectorDurant, jeanneDupont } from '../objetsPretsALEmploi';
-import { EntrepotUtilisateurMemoire } from '../../persistance/entrepotUtilisateurMemoire';
 
 describe('La ressource des services et ressources favoris', () => {
   let serveur: Express;
@@ -86,17 +86,6 @@ describe('La ressource des services et ressources favoris', () => {
       assert.equal(ceuxDeUtilisateur.length, 1);
       assert.equal(ceuxDeUtilisateur[0].idItemCyber, 'unId');
       assert.deepEqual(ceuxDeUtilisateur[0].utilisateur, jeanneDupont);
-    });
-
-    it('aseptise le contenu du body et remet les slash en place', async () => {
-      await request(serveur)
-        .post('/api/favoris')
-        .set('Cookie', [cookieJeanneDupont])
-        .send({ idItemCyber: '/services/mon-service-cyber  ' });
-
-      const ceuxDeUtilisateur = await entrepotFavori.tousCeuxDeUtilisateur(jeanneDupont);
-
-      assert.equal(ceuxDeUtilisateur[0].idItemCyber, '/services/mon-service-cyber');
     });
   });
 

--- a/back/tests/api/middleware.spec.ts
+++ b/back/tests/api/middleware.spec.ts
@@ -48,48 +48,6 @@ describe('Le middleware', () => {
     });
   });
 
-  describe("sur demande d'aseptisation", () => {
-    it('supprime les espaces au début et à la fin du paramètre', async () => {
-      requete.body.param = '  une valeur ';
-      let valeurAseptisee;
-      const suite = () => (valeurAseptisee = requete.body.param);
-
-      await middleware.aseptise('param')(requete, reponse, suite);
-
-      assert.equal(valeurAseptisee, 'une valeur');
-    });
-
-    it('prend en compte plusieurs paramètres', async () => {
-      requete.body.paramRenseigne = '  une valeur ';
-      let valeurAseptisee;
-      const suite = () => (valeurAseptisee = requete.body.paramRenseigne);
-
-      await middleware.aseptise('paramAbsent', 'paramRenseigne')(requete, reponse, suite);
-
-      assert.equal(valeurAseptisee, 'une valeur');
-    });
-
-    it('neutralise le code HTML', async () => {
-      requete.body.paramRenseigne = '<script>alert("hacked!");</script>';
-      const suite = () => (paramRenseigne = requete.body.paramRenseigne);
-      let paramRenseigne;
-
-      await middleware.aseptise('paramRenseigne')(requete, reponse, suite);
-
-      assert.equal(paramRenseigne, '&lt;script&gt;alert(&quot;hacked!&quot;);&lt;&#x2F;script&gt;');
-    });
-
-    it('aseptise les paramètres de la requête', async () => {
-      requete.params.paramRenseigne = '<script>alert("hacked!");</script>';
-      const suite = () => (paramRenseigne = requete.params.paramRenseigne);
-      let paramRenseigne;
-
-      await middleware.aseptise('paramRenseigne')(requete, reponse, suite);
-
-      assert.equal(paramRenseigne, '&lt;script&gt;alert(&quot;hacked!&quot;);&lt;&#x2F;script&gt;');
-    });
-  });
-
   describe("sur demande d'interdiction de mise en cache", () => {
     it('interdit la mise en cache', async () => {
       let headers: OutgoingHttpHeaders = {};

--- a/back/tests/api/mon-aide-cyber/ressourceDemandesAide.spec.ts
+++ b/back/tests/api/mon-aide-cyber/ressourceDemandesAide.spec.ts
@@ -124,9 +124,9 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
 
       await request(serveur)
         .post('/api/mon-aide-cyber/demandes-aide')
-        .send(uneDemandeAide({ email: '   durant@mail.fr   ' }));
+        .send(uneDemandeAide({ email: 'durant&@mail.fr' }));
 
-      assert.equal(emailEnvoye, 'durant@mail.fr');
+      assert.equal(emailEnvoye, 'durant&amp;@mail.fr');
     });
 
     it('pour le mail de l’Aidant si l’entité est en relation', async () => {
@@ -137,22 +137,9 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
 
       await request(serveur)
         .post('/api/mon-aide-cyber/demandes-aide')
-        .send(uneDemandeAide({ emailAidant: '   aidant@mail.fr   ' }));
+        .send(uneDemandeAide({ emailAidant: 'aidant&@mail.fr' }));
 
-      assert.equal(emailEnvoye, 'aidant@mail.fr');
-    });
-
-    it('pour le département de l’entité', async () => {
-      let departementEnvoye: string = '';
-      adaptateurMonAideCyber.creeDemandeAide = async ({ entiteAidee: { departement } }: DemandeAide) => {
-        departementEnvoye = departement;
-      };
-
-      await request(serveur)
-        .post('/api/mon-aide-cyber/demandes-aide')
-        .send(uneDemandeAide({ departement: '   12   ' }));
-
-      assert.equal(departementEnvoye, '12');
+      assert.equal(emailEnvoye, 'aidant&amp;@mail.fr');
     });
 
     it('pour la raison sociale de l’entité', async () => {
@@ -167,31 +154,11 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
           uneDemandeAide({
             email: 'durant@mail.fr',
             departement: '12',
-            raisonSociale: '   Une raison sociale   ',
+            raisonSociale: 'Une raison <sociale>',
           })
         );
 
-      assert.equal(raisonSocialeEnvoyee, 'Une raison sociale');
-    });
-
-    it('pour l’identifiant de l’Aidant', async () => {
-      let identifiantAidantEnvoye: string | undefined = undefined;
-      adaptateurMonAideCyber.creeDemandeAide = async ({ aidant }: DemandeAide) => {
-        identifiantAidantEnvoye = aidant.identifiant;
-      };
-
-      await request(serveur)
-        .post('/api/mon-aide-cyber/demandes-aide')
-        .send(
-          uneDemandeAide({
-            email: 'durant@mail.fr',
-            departement: '12',
-            raisonSociale: 'Une raison sociale',
-            identifiantAidant: '   a5b9ee4c-4eca-432d-ba96-da387fe6d5ed  ',
-          })
-        );
-
-      assert.equal(identifiantAidantEnvoye, 'a5b9ee4c-4eca-432d-ba96-da387fe6d5ed');
+      assert.equal(raisonSocialeEnvoyee, 'Une raison &lt;sociale&gt;');
     });
   });
 
@@ -268,7 +235,7 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
         .send({
           email: 'jean.dupont@mail.fr',
           validationCGU: true,
-          entite: { departement: '1000', raisonSociale: 'Une raison sociale' },
+          entiteAidee: { departement: '1000', raisonSociale: 'Une raison sociale' },
         });
 
       assert.equal(reponse.status, 400);
@@ -283,7 +250,7 @@ describe('Quand requête POST sur `/api/mon-aide-cyber/demandes-aide`', () => {
           validationCGU: true,
           entiteAidee: {
             departement: '01',
-            raisonSociale: '   ',
+            raisonSociale: '',
             siret: '12345678901234',
           },
         });

--- a/back/tests/api/ressourceAnnuaireOrganisations.spec.ts
+++ b/back/tests/api/ressourceAnnuaireOrganisations.spec.ts
@@ -16,27 +16,6 @@ describe('quand requête GET sur `/api/annuaire/organisations`', () => {
     serveur = creeServeur(configurationDeTestDuServeur);
   });
 
-  it('aseptise les paramètres de la requête', async () => {
-    let termeCherche;
-    let departementCherche;
-    const unAdaptateurRechercheEntreprise: AdaptateurRechercheEntreprise = {
-      rechercheOrganisations: async (terme: string, departement: string | null) => {
-        termeCherche = terme;
-        departementCherche = departement;
-        return [];
-      },
-    };
-    serveur = creeServeur({
-      ...configurationDeTestDuServeur,
-      adaptateurRechercheEntreprise: unAdaptateurRechercheEntreprise,
-    });
-
-    await request(serveur).get('/api/annuaire/organisations?recherche=ma>recherche&departement=33      ');
-
-    assert.equal(termeCherche, 'ma&gt;recherche');
-    assert.equal(departementCherche, '33');
-  });
-
   it('retourne une erreur HTTP 400 si le terme de recherche est vide', async () => {
     const reponse = await request(serveur).get('/api/annuaire/organisations?recherche=&departement=mon>departement');
     assert.equal(reponse.status, 400);

--- a/back/tests/api/ressourceAvisUtilisateur.spec.ts
+++ b/back/tests/api/ressourceAvisUtilisateur.spec.ts
@@ -87,22 +87,5 @@ describe('La ressource avis utilisateur', () => {
       assert.equal(reponse.status, 400);
       assert.equal(reponse.body.erreur, "L'email est invalide");
     });
-
-    it('asseptise le champ commentaire', async () => {
-      let avisUtilisateurEnvoye: AvisUtilisateur | undefined;
-      messagerieInstantanee.notifieUnAvisUtilisateur = async (avisUtilisateur: AvisUtilisateur) => {
-        avisUtilisateurEnvoye = avisUtilisateur;
-      };
-
-      await request(serveur)
-        .post('/api/avis-utilisateur')
-        .send({ ...avisUtilisateur, commentaire: '<span>Bonjour !</span>' });
-
-      assert.deepEqual(avisUtilisateurEnvoye, {
-        niveauDeSatisfaction: 2,
-        commentaire: '&lt;span&gt;Bonjour !&lt;&#x2F;span&gt;',
-        emailDeContact: 'mon.mail@mail.com',
-      });
-    });
   });
 });

--- a/back/tests/api/ressourcePageCrisp.spec.ts
+++ b/back/tests/api/ressourcePageCrisp.spec.ts
@@ -1,11 +1,11 @@
+import { Express } from 'express';
+import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
 import request from 'supertest';
-import { Express } from 'express';
 import { creeServeur } from '../../src/api/msc';
-import { configurationDeTestDuServeur, fauxAdaptateurEnvironnement } from './fauxObjets';
-import assert from 'node:assert';
-import { MockCmsCrisp } from '../mockCmsCrisp';
 import { AdaptateurEnvironnement } from '../../src/infra/adaptateurEnvironnement';
+import { MockCmsCrisp } from '../mockCmsCrisp';
+import { configurationDeTestDuServeur, fauxAdaptateurEnvironnement } from './fauxObjets';
 
 describe('quand requête GET sur `/api/pages-crisp/un-id-d-article`', () => {
   let serveur: Express;
@@ -70,18 +70,5 @@ describe('quand requête GET sur `/api/pages-crisp/un-id-d-article`', () => {
     const reponse = await request(serveur).get('/api/pages-crisp/id_inconnu');
 
     assert.equal(reponse.status, 404);
-  });
-
-  it('aseptise les paramètres de la requête', async () => {
-    cmsCrisp.ajouteArticle('ID_&GT;ID', {
-      titre: 'AseptisationOk',
-      description: '',
-      contenu: '',
-      tableDesMatieres: [],
-    });
-    const reponse = await request(serveur).get('/api/pages-crisp/>id');
-
-    const page = reponse.body;
-    assert.equal(page.titre, 'AseptisationOk');
   });
 });

--- a/back/tests/api/ressourcePageProduit.spec.ts
+++ b/back/tests/api/ressourcePageProduit.spec.ts
@@ -1,10 +1,10 @@
-import { beforeEach, describe, it } from 'node:test';
 import { Express } from 'express';
-import { FournisseurChemin } from '../../src/api/fournisseurChemin';
-import { join } from 'path';
-import { creeServeur } from '../../src/api/msc';
-import request from 'supertest';
 import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+import { join } from 'path';
+import request from 'supertest';
+import { FournisseurChemin } from '../../src/api/fournisseurChemin';
+import { creeServeur } from '../../src/api/msc';
 import { configurationDeTestDuServeur, fauxFournisseurDeChemin } from './fauxObjets';
 
 describe('La ressource page produit', () => {
@@ -46,18 +46,6 @@ describe('La ressource page produit', () => {
 
       assert.equal(repertoireProduitsDemande!, 'services');
       assert.equal(idProduitDemande!, 'mon-service-securise');
-    });
-
-    it("aseptise l'id du produit", async () => {
-      let idProduitDemande: string;
-      fournisseurChemin.cheminProduitJekyll = (_: string, idProduit: string) => {
-        idProduitDemande = idProduit;
-        return join(process.cwd(), 'tests', 'ressources', 'factice.html');
-      };
-
-      await request(serveur).get('/services/mon>service');
-
-      assert.equal(idProduitDemande!, 'mon&gt;service');
     });
   });
 

--- a/back/tests/api/ressourceRetoursExperience.spec.ts
+++ b/back/tests/api/ressourceRetoursExperience.spec.ts
@@ -87,20 +87,6 @@ describe("La ressource des retours d'expérience", () => {
       assert.equal(reponse.status, 201);
     });
 
-    it('aseptise les paramètres', async () => {
-      let retourExperienceEnvoye: RetourExperience | null = null;
-      messagerieInstantanee.notifieUnRetourExperience = async (retourExperience: RetourExperience) => {
-        retourExperienceEnvoye = retourExperience;
-      };
-
-      await request(serveur).post('/api/retours-experience').send({
-        raison: 'pas-clair',
-        precision: '  <>',
-      });
-
-      assert.equal(retourExperienceEnvoye!.precision, '&lt;&gt;');
-    });
-
     it('accepte la raison pas-decisionnaire', async () => {
       const reponse = await request(serveur).post('/api/retours-experience').send({
         raison: 'pas-decisionnaire',

--- a/back/tests/api/ressourceUtilisateurs.spec.ts
+++ b/back/tests/api/ressourceUtilisateurs.spec.ts
@@ -131,42 +131,6 @@ describe('La ressource utilisateur', () => {
       assert.equal(evenement!.telephone, '0123456789');
     });
 
-    it('aseptise les paramètres', async () => {
-      adaptateurRechercheEntreprise.rechercheOrganisations = async () => [
-        {
-          nom: '',
-          departement: '',
-          siret: '13000766900018',
-          codeTrancheEffectif: '01',
-          codeRegion: 'FR-ARA',
-          codeSecteur: 'D',
-          estAssociation: false,
-          estCollectivite: false,
-          codeActivite: '62.01Z',
-        },
-      ];
-
-      await request(serveur)
-        .post('/api/utilisateurs')
-        .send({
-          email: '  jeanne.dupont@user.com',
-          prenom: '<Jeanne',
-          nom: '<Dupont',
-          telephone: ' 0123456789',
-          domainesSpecialite: [' RSSI'],
-          siretEntite: ' 13000766900018',
-          cguAcceptees: true,
-          infolettreAcceptee: true,
-          token: donneesUtilisateur.token,
-        });
-
-      const jeanne = await entrepotUtilisateur.parEmailHache('jeanne.dupont@user.com-hache');
-      assert.notEqual(jeanne, undefined);
-      assert.equal(jeanne?.telephone, '0123456789');
-      assert.deepEqual(jeanne?.domainesSpecialite, ['RSSI']);
-      assert.equal((await jeanne?.organisation())?.siret, '13000766900018');
-    });
-
     describe('concernant la validation des données', () => {
       it('valide le téléphone', async () => {
         const reponse = await request(serveur)

--- a/back/tests/api/testMaturite/ressourceResultatsDeTest.spec.ts
+++ b/back/tests/api/testMaturite/ressourceResultatsDeTest.spec.ts
@@ -343,15 +343,6 @@ describe('La ressource qui gère les résultats de test de maturité', () => {
           assert.equal(reponse.status, 400);
           assert.equal(reponse.body.erreur, 'Les valeurs de réponses doivent être comprises entre 1 et 5');
         });
-
-        it('aseptise le code de session de groupe', async () => {
-          await requeteAvecDonneeIncorrecte({
-            codeSessionGroupe: ' ABC2ED ',
-          });
-
-          const evenement = busEvenements.recupereEvenement(TestRealise);
-          assert.equal(evenement!.codeSessionGroupe, 'ABC2ED');
-        });
       });
     });
 

--- a/back/tests/api/testMaturite/ressourceSessionDeGroupe.spec.ts
+++ b/back/tests/api/testMaturite/ressourceSessionDeGroupe.spec.ts
@@ -1,12 +1,12 @@
+import { Express } from 'express';
+import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
 import request from 'supertest';
-import assert from 'node:assert';
 import { creeServeur } from '../../../src/api/msc';
-import { configurationDeTestDuServeur } from '../fauxObjets';
-import { Express } from 'express';
 import { EntrepotSessionDeGroupe } from '../../../src/metier/entrepotSessionDeGroupe';
-import { EntrepotSessionDeGroupeMemoire } from '../../persistance/EntrepotSessionDeGroupeMemoire';
 import { SessionDeGroupe } from '../../../src/metier/sessionDeGroupe';
+import { EntrepotSessionDeGroupeMemoire } from '../../persistance/EntrepotSessionDeGroupeMemoire';
+import { configurationDeTestDuServeur } from '../fauxObjets';
 
 describe('La ressource qui gère une session de groupe', () => {
   let serveur: Express;
@@ -33,14 +33,6 @@ describe('La ressource qui gère une session de groupe', () => {
       const reponse = await request(serveur).get('/api/sessions-groupe/ABC2ED').send({});
 
       assert.equal(reponse.status, 404);
-    });
-
-    it('aseptise le code passé en paramètre', async () => {
-      await entrepotSessionDeGroupe.ajoute(new SessionDeGroupe('ABC2&lt;D'));
-
-      const reponse = await request(serveur).get('/api/sessions-groupe/ABC2<D').send({});
-
-      assert.equal(reponse.status, 200);
     });
   });
 });


### PR DESCRIPTION
... pour suivre le principe de "Validation des entrées, aseptisation des sorties".

Pour les sorties en HTML, nous utilisons Svelte ou une aseptisation manuelle pour empêcher les XSS.

Pour les sorties vers Mattermost, on aseptise aussi manuellement.

Pour les sorties vers le bus d'événements et MAC, on encode les données pour rester consistant avec les données précédemment stockées là-bas.

> [!WARNING]
> Cette PR change la façon de stocker les données en base, il va falloir migrer les données existantes avant le déploiement pour éviter de mélanger des données encodées et non-encodées dans les mêmes champs de la base de données.