### PR TITLE
Corrige la comparaison NIS 2

### DIFF
--- a/back/src/api/nis2/ressourceExigencesNis2.schema.ts
+++ b/back/src/api/nis2/ressourceExigencesNis2.schema.ts
@@ -3,8 +3,8 @@ import { referentiels } from '../../metier/nis2/exigence';
 
 export const schemaRessourceExigencesNis2 = z.object({
   query: z.object({
-    source: z.enum(referentiels, 'Les paramètres doivent être des chaînes de caractères').optional(),
-    cible: z.enum(referentiels, 'Les paramètres doivent être des chaînes de caractères').optional(),
+    source: z.enum(referentiels, 'Les paramètres doivent être des chaînes de caractères').or(z.string('')).optional(),
+    cible: z.enum(referentiels, 'Les paramètres doivent être des chaînes de caractères').or(z.string('')).optional(),
     langue: z.string().length(2, 'La langue doit être une chaîne de 2 caractères').optional(),
   }),
 });

--- a/front/lib-svelte/src/nis2/ExigencesNis2.svelte
+++ b/front/lib-svelte/src/nis2/ExigencesNis2.svelte
@@ -19,7 +19,7 @@
 
   let mode = $state<'LISTE' | Comparaison>('LISTE');
 
-  let referentielSelectionne = $state<ReferentielSelectionne | undefined>(undefined);
+  let referentielSelectionne = $state<ReferentielSelectionne | ''>('');
   let langueSelectionnee = $state<'FR' | 'EN'>('FR');
   let estBureau = $state(false);
   let chargement = $state(false);
@@ -28,7 +28,7 @@
     const axiosResponse = await axios.get<Record<string, unknown>[]>('/api/exigences-nis2', {
       params: { source, cible, langue: langueSelectionnee },
     });
-    exigences = axiosResponse.data.map((e) => fabriqueDExigence(source ?? 'NIS2', cible, e));
+    exigences = axiosResponse.data.map((e) => fabriqueDExigence(source.length === 0 ? 'NIS2' : source, cible, e));
     $exigencesStore = exigences;
   };
 
@@ -40,7 +40,11 @@
     estBureau = mql.matches;
   });
 
-  const source = $derived(sensComparaison === 'NIS2_VERS_CIBLE' ? 'NIS2' : referentielSelectionne);
+  const source = $derived(
+    sensComparaison === 'NIS2_VERS_CIBLE'
+      ? 'NIS2'
+      : ((referentielSelectionne.length > 0 ? referentielSelectionne : 'NIS2') as Exclude<ReferentielSelectionne, ''>)
+  );
 
   const cible = $derived(sensComparaison === 'SOURCE_VERS_NIS2' ? 'NIS2' : referentielSelectionne);
 
@@ -120,7 +124,9 @@
     </div>
 
     <Panneau
-      source={sensComparaison === 'NIS2_VERS_CIBLE' ? 'NIS2' : (referentielSelectionne ?? 'NIS2')}
+      source={sensComparaison === 'NIS2_VERS_CIBLE'
+        ? 'NIS2'
+        : ((referentielSelectionne ?? 'NIS2') as Exclude<ReferentielSelectionne, ''>)}
       bind:referentielSelectionne
       bind:langueSelectionnee
       bind:sensComparaison

--- a/front/lib-svelte/src/nis2/exigence.type.ts
+++ b/front/lib-svelte/src/nis2/exigence.type.ts
@@ -137,7 +137,7 @@ export const formateContenuExigence = ({ contenu }: ExigenceBase | ExigenceCompa
 
 export const fabriqueDExigence = (
   source: Referentiel,
-  cible: Referentiel | undefined,
+  cible: Referentiel | '',
   exigence: Record<string, unknown>
 ): Exigence => {
   const correspondances = exigence.correspondances as Record<string, Correspondance>;
@@ -150,7 +150,7 @@ export const fabriqueDExigence = (
       thematique: (exigence.thematique as string) ?? '',
       entitesCible: (exigence.entitesCible as CategorieEntite[]) ?? [],
 
-      correspondance: cible && correspondances[cible],
+      correspondance: cible ? correspondances[cible] : undefined,
     } satisfies ExigenceNis2;
   } else if (source === 'ISO') {
     return {

--- a/front/lib-svelte/src/nis2/panneau/BoutonReinitialisation.svelte
+++ b/front/lib-svelte/src/nis2/panneau/BoutonReinitialisation.svelte
@@ -6,7 +6,7 @@
   type Props = {
     langueSelectionnee: 'FR' | 'EN';
     sensComparaison: 'NIS2_VERS_CIBLE' | 'SOURCE_VERS_NIS2';
-    referentielSelectionne: ReferentielSelectionne | undefined;
+    referentielSelectionne: ReferentielSelectionne | '';
   };
   let {
     langueSelectionnee = $bindable('FR'),
@@ -15,7 +15,7 @@
   }: Props = $props();
 
   const reinitialise = async () => {
-    referentielSelectionne = undefined;
+    referentielSelectionne = '';
     sensComparaison = 'NIS2_VERS_CIBLE';
     langueSelectionnee = 'FR';
     $exigencesFiltrees.reinitialise();

--- a/front/lib-svelte/src/nis2/panneau/Panneau.svelte
+++ b/front/lib-svelte/src/nis2/panneau/Panneau.svelte
@@ -11,7 +11,7 @@
     estBureau: boolean;
     sensComparaison: 'NIS2_VERS_CIBLE' | 'SOURCE_VERS_NIS2';
     source: Referentiel;
-    referentielSelectionne: ReferentielSelectionne | undefined;
+    referentielSelectionne: ReferentielSelectionne | '';
     langueSelectionnee: 'FR' | 'EN';
     featureFlagNis2CyFun23: boolean;
   };

--- a/front/lib-svelte/src/nis2/panneau/PanneauComparaison.svelte
+++ b/front/lib-svelte/src/nis2/panneau/PanneauComparaison.svelte
@@ -6,7 +6,7 @@
   type Props = {
     estBureau: boolean;
     sensComparaison: 'NIS2_VERS_CIBLE' | 'SOURCE_VERS_NIS2';
-    referentielSelectionne: ReferentielSelectionne | undefined;
+    referentielSelectionne: ReferentielSelectionne | '';
     langueSelectionnee: 'FR' | 'EN';
     featureFlagNis2CyFun23: boolean;
   };

--- a/front/lib-svelte/src/nis2/panneau/PanneauFiltres.svelte
+++ b/front/lib-svelte/src/nis2/panneau/PanneauFiltres.svelte
@@ -18,7 +18,7 @@
   type Props = {
     estBureau: boolean;
     source: Referentiel;
-    cible: ReferentielSelectionne | undefined;
+    cible: ReferentielSelectionne | '';
   };
 
   const { source, cible, estBureau }: Props = $props();


### PR DESCRIPTION
L'utilisation du `<dsfr-select>` a perturbé les filtres car il n'accepte pas `undefined` comme clé