### PR TITLE
[CORRECTION] Isole et ignore les erreurs de flux

### DIFF
--- a/back/src/api/gestionnaireRessourceCellar.ts
+++ b/back/src/api/gestionnaireRessourceCellar.ts
@@ -17,8 +17,15 @@ export const fabriqueGestionnaireRessourceCellar = (
     try {
       const nomDuDocument = requete.params.slug as string;
       const fluxCellar = await cellar.getStream(nomDuDocument, cleDuBucket);
+
       if (!fluxCellar) {
         await fnDocumentManquant(reponse, nomDuDocument);
+        return;
+      }
+
+      // Si le client a déjà fermé la connexion, on abandonne proprement
+      if (reponse.destroyed || reponse.closed) {
+        fluxCellar.flux.destroy();
         return;
       }
 
@@ -30,7 +37,32 @@ export const fabriqueGestionnaireRessourceCellar = (
         expires: '3600',
         'surrogate-control': 'public, max-age=3600, s-maxage=3600, must-revalidate, proxy-revalidate',
       });
-      await pipeline(fluxCellar.flux, reponse);
+
+      // On écoute la déconnexion client pour détruire le flux source
+      const detruireFluxSiDeconnexion = () => {
+        fluxCellar.flux.destroy();
+      };
+      requete.on('close', detruireFluxSiDeconnexion);
+
+      try {
+        await pipeline(fluxCellar.flux, reponse);
+      } catch (erreurPipeline: Error | unknown) {
+        // On ignore les erreurs dues à une déconnexion cliente volontaire
+        const estDeconnexionClient =
+          reponse.destroyed ||
+          (erreurPipeline instanceof Error &&
+            (erreurPipeline.message.includes('closed') ||
+              erreurPipeline.message.includes('destroyed') ||
+              (erreurPipeline as NodeJS.ErrnoException).code === 'ERR_STREAM_DESTROYED' ||
+              (erreurPipeline as NodeJS.ErrnoException).code === 'ECONNRESET' ||
+              (erreurPipeline as NodeJS.ErrnoException).code === 'EPIPE'));
+
+        if (!estDeconnexionClient) {
+          throw erreurPipeline;
+        }
+      } finally {
+        requete.off('close', detruireFluxSiDeconnexion);
+      }
     } catch (erreur: Error | unknown) {
       suite(erreur);
     }


### PR DESCRIPTION
...lorsque que celles-ci sont dues à une interruption côté client