### PR TITLE
[BUG] Retire un style inutilisé

### DIFF
--- a/front/_includes/head.html
+++ b/front/_includes/head.html
@@ -28,7 +28,6 @@
   <link rel="stylesheet" href="{{ "/assets/styles/site.css" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/styles/boutons.css" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/styles/fonts.css" | relative_url }}">
-  <link rel="stylesheet" href="{{ "/lib-svelte/dist/assets/style.css" | relative_url }}">
   {% for style in layout.styles %}
     <link rel="stylesheet" href="{{ style | relative_url }}">
   {% endfor %}


### PR DESCRIPTION
...depuis le commit a9989ad776dc8a638195d71a3079a1e13e54806e et la possibilité d’utiliser les composants en WebComponents, le fichier style.css n’est plus généré mais les styles sont injectés dans les fichiers js générés par Svelte.