### PR TITLE
[SECU] Sers le haché de la liste de confiance

### DIFF
--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -31,6 +31,7 @@ import { ressourceAnnuaireRegions } from './ressourceAnnuaireRegions';
 import { ressourceAnnuaireSecteursActivite } from './ressourceAnnuaireSecteursActivite';
 import { ressourceAnnuaireTranchesEffectif } from './ressourceAnnuaireTranchesEffectif';
 import { ressourceAvisUtilisateur } from './ressourceAvisUtilisateur';
+import { ressourceControleContenuListeConfiance } from './ressourceControleContenuListeConfiance';
 import { ressourceDocumentRessource } from './ressourceDocumentRessource';
 import { ressourceFinancement } from './ressourceFinancement';
 import { ressourceFinancements } from './ressourceFinancements';
@@ -258,6 +259,7 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
   app.use('/documents-guides', ressourceDocumentGuide(configurationServeur));
   app.use('/documents-ressources', ressourceDocumentRessource(configurationServeur));
 
+  app.use('/visas/tl-fr.sha2', ressourceControleContenuListeConfiance());
   app.use('/visas', ressourceVisa(configurationServeur));
 
   app.use('/api/diagnostic/statistiques', ressourceStatistiquesDiagnostic());

--- a/back/src/api/ressourceControleContenuListeConfiance.ts
+++ b/back/src/api/ressourceControleContenuListeConfiance.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { corpsVide, valideCorpsRequete } from './zod';
+
+export const ressourceControleContenuListeConfiance = () => {
+  const routeur = Router();
+  routeur.get('/', valideCorpsRequete(corpsVide), (_requete, reponse) => {
+    reponse.send(Buffer.from('49daa29a23ab75a58009dce5e2cda4bdd1912e47b07015b2980023f26d581e8b'));
+  });
+  return routeur;
+};

--- a/back/tests/api/ressourceVisa.spec.ts
+++ b/back/tests/api/ressourceVisa.spec.ts
@@ -97,5 +97,34 @@ describe('La ressource de visa', () => {
         assert.equal(reponse.status, 404);
       });
     });
+
+    describe('concernant le fichier de contrôle', () => {
+      it('n’appelle pas l’adaptateur cellar', async () => {
+        let estAppelle: boolean = false;
+        adaptateurCellar.getStream = async () => {
+          estAppelle = true;
+          return undefined;
+        };
+
+        await request(serveur).get('/visas/tl-fr.sha2');
+
+        assert.equal(estAppelle, false);
+      });
+
+      it('retourne un statut OK', async () => {
+        const reponse = await request(serveur).get('/visas/tl-fr.sha2');
+
+        assert.equal(reponse.status, 200);
+      });
+
+      it('retourne le haché de la liste de confiance', async () => {
+        const reponse = await request(serveur).get('/visas/tl-fr.sha2');
+
+        assert.equal(
+          (reponse.body as Buffer).toString(),
+          '49daa29a23ab75a58009dce5e2cda4bdd1912e47b07015b2980023f26d581e8b'
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
...afin de renforcer la sécurité de cette liste. Si un attaquant parvenait à altérer le contenu de la liste de confiance sur notre serveur de stockage, il pourrait également mettre à jour ce haché. En le fournissant depuis le code, il faut également modifier ce dernier pour altérer le haché.