### PR TITLE
Isole les mesures par module

### DIFF
--- a/back/src/admin/consoleAdministration.ts
+++ b/back/src/admin/consoleAdministration.ts
@@ -4,6 +4,7 @@ import pThrottle from 'p-throttle';
 import config from '../../knexfile';
 import { CompteCree } from '../bus/evenements/compteCree';
 import { MiseAJourFavorisUtilisateur } from '../bus/miseAJourFavorisUtilisateur';
+import { EntrepôtModulePostgres } from '../entrepotModulePostgres';
 import { AdaptateurChiffrement, fabriqueAdaptateurChiffrement } from '../infra/adaptateurChiffrement';
 import { fabriqueAdaptateurEmail } from '../infra/adaptateurEmailBrevo';
 import { adaptateurEnvironnement } from '../infra/adaptateurEnvironnement';
@@ -20,10 +21,10 @@ import { EntrepotMesurePostgres } from '../infra/entrepotMesurePostgres';
 import { EntrepotUtilisateurMPAPostgres } from '../infra/entrepotUtilisateurMPAPostgres';
 import { EntrepotExigenceGrist } from '../infra/nis2/entrepotExigenceGrist';
 import { UtilisateurBDD } from '../infra/utilisateurBDD';
-import { EntrepotExigence } from '../metier/nis2/entrepotExigence';
 import { AdaptateurEmail } from '../metier/adaptateurEmail';
 import { EntrepotFavori } from '../metier/entrepotFavori';
 import { EntrepotUtilisateur } from '../metier/entrepotUtilisateur';
+import { EntrepotExigence } from '../metier/nis2/entrepotExigence';
 import { CodeRegion } from '../metier/referentielRegions';
 import { CodeSecteur } from '../metier/referentielSecteurs';
 import { CodeTrancheEffectif } from '../metier/referentielTranchesEffectifEtablissement';
@@ -54,7 +55,8 @@ export class ConsoleAdministration {
     const entrepotExigence: EntrepotExigence = new EntrepotExigenceGrist({
       adaptateurEnvironnement,
     });
-    const entrepotMesure = new EntrepotMesurePostgres(entrepotExigence);
+    const entrepôtModule = new EntrepôtModulePostgres();
+    const entrepotMesure = new EntrepotMesurePostgres(entrepotExigence, entrepôtModule);
 
     this.entrepotUtilisateur = new EntrepotUtilisateurMPAPostgres({
       adaptateurProfilAnssi,

--- a/back/src/api/configurationServeur.ts
+++ b/back/src/api/configurationServeur.ts
@@ -14,6 +14,7 @@ import { EntrepotFinancement } from '../metier/entrepotFinancement';
 import { EntrepotGuide } from '../metier/entrepotGuide';
 import { EntrepotGuideTravail } from '../metier/entrepotGuideTravail';
 import { EntrepotMesure } from '../metier/entrepotMesure';
+import { EntrepôtModule } from '../metier/EntrepotModule';
 import { EntrepotPriseEnCompte } from '../metier/entrepotPriseEnCompte';
 import { EntrepotResultatTest } from '../metier/entrepotResultatTest';
 import { EntrepotSessionDeGroupe } from '../metier/entrepotSessionDeGroupe';
@@ -48,6 +49,7 @@ export type ConfigurationServeur = {
   entrepotExigence: EntrepotExigence;
   entrepotMesure: EntrepotMesure;
   entrepotPriseEnCompte: EntrepotPriseEnCompte;
+  entrepôtModule: EntrepôtModule;
   fournisseurChemin: FournisseurChemin;
   generateurCodeSessionDeGroupe: GenerateurCodeSessionDeGroupe;
   messagerieInstantanee: MessagerieInstantanee;

--- a/back/src/api/mesures/mesurePresentation.ts
+++ b/back/src/api/mesures/mesurePresentation.ts
@@ -1,8 +1,9 @@
 import { Mesure } from '../../metier/mesure';
 
 export const mesurePresentation = async (mesure: Mesure, estPriseEnCompte: boolean) => {
+  const { module: _module, ...reste } = mesure;
   return {
-    ...mesure,
+    ...reste,
     estPriseEnCompte,
   };
 };

--- a/back/src/api/mesures/ressourceMesuresDeModule.ts
+++ b/back/src/api/mesures/ressourceMesuresDeModule.ts
@@ -21,6 +21,9 @@ const ressourceMesuresDeModule = ({
     valideCorpsRequete(corpsVide),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
       const module = await entrepôtModule.parId(Number.parseInt(requete.params.idModule as string));
+      if (!module) {
+        return reponse.sendStatus(404);
+      }
       const mesures = await entrepotMesure.duModule(module!);
       const utilisateur = requete.utilisateur as Utilisateur;
 

--- a/back/src/api/mesures/ressourceMesuresDeModule.ts
+++ b/back/src/api/mesures/ressourceMesuresDeModule.ts
@@ -33,7 +33,7 @@ const ressourceMesuresDeModule = ({
         })
       );
       const mesuresTries = mesuresPresentation.toSorted((a, b) => a.ordre - b.ordre);
-      reponse.status(200).send(mesuresTries);
+      reponse.status(200).send({ mesures: mesuresTries });
     })
   );
 

--- a/back/src/api/mesures/ressourceMesuresDeModule.ts
+++ b/back/src/api/mesures/ressourceMesuresDeModule.ts
@@ -15,7 +15,7 @@ const ressourceMesuresDeModule = ({
   const routeur = Router();
 
   routeur.get(
-    '/:idModule/mesures',
+    '/:idModule',
     middleware.verifieJWT,
     middleware.ajouteUtilisateurARequete(entrepotUtilisateur, adaptateurHachage),
     valideCorpsRequete(corpsVide),

--- a/back/src/api/mesures/ressourceMesuresDeModule.ts
+++ b/back/src/api/mesures/ressourceMesuresDeModule.ts
@@ -8,18 +8,20 @@ import { mesurePresentation } from './mesurePresentation';
 const ressourceMesuresDeModule = ({
   entrepotMesure,
   entrepotUtilisateur,
+  entrepôtModule,
   adaptateurHachage,
   middleware,
 }: ConfigurationServeur) => {
   const routeur = Router();
 
   routeur.get(
-    '/',
+    '/:idModule/mesures',
     middleware.verifieJWT,
     middleware.ajouteUtilisateurARequete(entrepotUtilisateur, adaptateurHachage),
     valideCorpsRequete(corpsVide),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
-      const mesures = await entrepotMesure.tous();
+      const module = await entrepôtModule.parId(Number.parseInt(requete.params.idModule as string));
+      const mesures = await entrepotMesure.duModule(module!);
       const utilisateur = requete.utilisateur as Utilisateur;
 
       const mesuresPresentation = await Promise.all(

--- a/back/src/api/mesures/ressourceModule.ts
+++ b/back/src/api/mesures/ressourceModule.ts
@@ -24,7 +24,8 @@ const ressourceModule = ({
       if (!module) {
         return reponse.sendStatus(404);
       }
-      const mesures = await entrepotMesure.duModule(module!);
+      const mesures = await entrepotMesure.duModule(module);
+      module.mesures = mesures;
       const utilisateur = requete.utilisateur as Utilisateur;
 
       const mesuresPresentation = await Promise.all(
@@ -33,7 +34,7 @@ const ressourceModule = ({
         })
       );
       const mesuresTries = mesuresPresentation.toSorted((a, b) => a.ordre - b.ordre);
-      reponse.status(200).send({ mesures: mesuresTries });
+      reponse.status(200).send({ cibleBadge: module.cibleDéblocageBadgeCyberdépart(), mesures: mesuresTries });
     })
   );
 

--- a/back/src/api/mesures/ressourceModule.ts
+++ b/back/src/api/mesures/ressourceModule.ts
@@ -2,8 +2,9 @@ import { Request, Response, Router } from 'express';
 import { Utilisateur } from '../../metier/utilisateur';
 import { ConfigurationServeur } from '../configurationServeur';
 import { filetRouteAsynchrone } from '../middleware';
-import { corpsVide, valideCorpsRequete } from '../zod';
+import { valideParametresRequete } from '../zod';
 import { mesurePresentation } from './mesurePresentation';
+import { schemaRessourceModule } from './schemaRessourceModule.schema';
 
 const ressourceModule = ({
   entrepotMesure,
@@ -18,7 +19,7 @@ const ressourceModule = ({
     '/:idModule',
     middleware.verifieJWT,
     middleware.ajouteUtilisateurARequete(entrepotUtilisateur, adaptateurHachage),
-    valideCorpsRequete(corpsVide),
+    valideParametresRequete(schemaRessourceModule),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
       const module = await entrepôtModule.parId(Number.parseInt(requete.params.idModule as string));
       if (!module) {

--- a/back/src/api/mesures/ressourceModule.ts
+++ b/back/src/api/mesures/ressourceModule.ts
@@ -5,7 +5,7 @@ import { filetRouteAsynchrone } from '../middleware';
 import { corpsVide, valideCorpsRequete } from '../zod';
 import { mesurePresentation } from './mesurePresentation';
 
-const ressourceMesuresDeModule = ({
+const ressourceModule = ({
   entrepotMesure,
   entrepotUtilisateur,
   entrepôtModule,
@@ -40,4 +40,4 @@ const ressourceMesuresDeModule = ({
   return routeur;
 };
 
-export { ressourceMesuresDeModule };
+export { ressourceModule };

--- a/back/src/api/mesures/ressourcePriseEnCompte.ts
+++ b/back/src/api/mesures/ressourcePriseEnCompte.ts
@@ -10,17 +10,20 @@ const mesureDeModule = async (
   idMesure: string,
   entrepotMesure: EntrepotMesure
 ): Promise<[Mesure | undefined, number]> => {
-  const toutesLesMesures = await entrepotMesure.tous();
-  const rang = toutesLesMesures.sort((a, b) => a.ordre - b.ordre).findIndex((m) => m.id === idMesure);
+  const mesure = await entrepotMesure.parId(idMesure);
+  if (!mesure) {
+    return [undefined, -1];
+  }
+  const mesuresDuModule = await entrepotMesure.duModule(mesure.module!);
+  const rang = mesuresDuModule.sort((a, b) => a.ordre - b.ordre).findIndex((m) => m.id === idMesure);
 
   if (rang === -1) {
     return [undefined, rang];
   }
 
-  const mesure = toutesLesMesures[rang];
   if (mesure.module) {
     //TODO : supprimer cette condition et cette façon de faire
-    mesure.module.mesures = toutesLesMesures;
+    mesure.module.mesures = mesuresDuModule;
   }
   return [mesure, rang];
 };

--- a/back/src/api/mesures/ressourcePriseEnCompte.ts
+++ b/back/src/api/mesures/ressourcePriseEnCompte.ts
@@ -6,26 +6,24 @@ import { ConfigurationServeur } from '../configurationServeur';
 import { filetRouteAsynchrone } from '../middleware';
 import { corpsVide, valideCorpsRequete } from '../zod';
 
-const mesureDeModule = async (
-  idMesure: string,
-  entrepotMesure: EntrepotMesure
-): Promise<[Mesure | undefined, number]> => {
+const mesureDeModule = async (idMesure: string, entrepotMesure: EntrepotMesure): Promise<Mesure | undefined> => {
   const mesure = await entrepotMesure.parId(idMesure);
   if (!mesure) {
-    return [undefined, -1];
+    return undefined;
   }
   const mesuresDuModule = await entrepotMesure.duModule(mesure.module!);
-  const rang = mesuresDuModule.sort((a, b) => a.ordre - b.ordre).findIndex((m) => m.id === idMesure);
-
-  if (rang === -1) {
-    return [undefined, rang];
-  }
-
   if (mesure.module) {
     //TODO : supprimer cette condition et cette façon de faire
     mesure.module.mesures = mesuresDuModule;
+    const rang = mesure.rangDansSonModule();
+
+    if (rang === -1) {
+      return undefined;
+    }
+
+    return mesure;
   }
-  return [mesure, rang];
+  return undefined;
 };
 
 export const ressourcePriseEnCompte = ({
@@ -47,13 +45,13 @@ export const ressourcePriseEnCompte = ({
       const utilisateur = requete.utilisateur as Utilisateur;
       const idMesure = requete.params.idMesure as string;
 
-      const [mesure, rang] = await mesureDeModule(idMesure, entrepotMesure);
+      const mesure = await mesureDeModule(idMesure, entrepotMesure);
 
       if (!mesure) {
         return reponse.sendStatus(404);
       }
 
-      await utilisateur.prendEnCompte(mesure, rang, entrepotPriseEnCompte, busEvenements, mesure.module!);
+      await utilisateur.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, mesure.module!);
 
       return reponse.sendStatus(201);
     })

--- a/back/src/api/mesures/ressourcePriseEnCompte.ts
+++ b/back/src/api/mesures/ressourcePriseEnCompte.ts
@@ -11,19 +11,15 @@ const mesureDeModule = async (idMesure: string, entrepotMesure: EntrepotMesure):
   if (!mesure) {
     return undefined;
   }
-  const mesuresDuModule = await entrepotMesure.duModule(mesure.module!);
-  if (mesure.module) {
-    //TODO : supprimer cette condition et cette façon de faire
-    mesure.module.mesures = mesuresDuModule;
-    const rang = mesure.rangDansSonModule();
+  //TODO : supprimer cette façon de faire
+  mesure.module.mesures = await entrepotMesure.duModule(mesure.module);
+  const rang = mesure.rangDansSonModule();
 
-    if (rang === -1) {
-      return undefined;
-    }
-
-    return mesure;
+  if (rang === -1) {
+    return undefined;
   }
-  return undefined;
+
+  return mesure;
 };
 
 export const ressourcePriseEnCompte = ({
@@ -51,7 +47,7 @@ export const ressourcePriseEnCompte = ({
         return reponse.sendStatus(404);
       }
 
-      await utilisateur.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, mesure.module!);
+      await utilisateur.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, mesure.module);
 
       return reponse.sendStatus(201);
     })

--- a/back/src/api/mesures/ressourcePriseEnCompte.ts
+++ b/back/src/api/mesures/ressourcePriseEnCompte.ts
@@ -9,16 +9,20 @@ import { corpsVide, valideCorpsRequete } from '../zod';
 const mesureDeModule = async (
   idMesure: string,
   entrepotMesure: EntrepotMesure
-): Promise<[Mesure | undefined, number, number]> => {
+): Promise<[Mesure | undefined, number]> => {
   const toutesLesMesures = await entrepotMesure.tous();
   const rang = toutesLesMesures.sort((a, b) => a.ordre - b.ordre).findIndex((m) => m.id === idMesure);
 
   if (rang === -1) {
-    return [undefined, rang, toutesLesMesures.length];
+    return [undefined, rang];
   }
 
   const mesure = toutesLesMesures[rang];
-  return [mesure, rang, toutesLesMesures.length];
+  if (mesure.module) {
+    //TODO : supprimer cette condition et cette façon de faire
+    mesure.module.mesures = toutesLesMesures;
+  }
+  return [mesure, rang];
 };
 
 export const ressourcePriseEnCompte = ({
@@ -40,13 +44,13 @@ export const ressourcePriseEnCompte = ({
       const utilisateur = requete.utilisateur as Utilisateur;
       const idMesure = requete.params.idMesure as string;
 
-      const [mesure, rang, taille] = await mesureDeModule(idMesure, entrepotMesure);
+      const [mesure, rang] = await mesureDeModule(idMesure, entrepotMesure);
 
       if (!mesure) {
         return reponse.sendStatus(404);
       }
 
-      await utilisateur.prendEnCompte(mesure, taille, rang, entrepotPriseEnCompte, busEvenements);
+      await utilisateur.prendEnCompte(mesure, rang, entrepotPriseEnCompte, busEvenements, mesure.module!);
 
       return reponse.sendStatus(201);
     })

--- a/back/src/api/mesures/schemaRessourceModule.schema.ts
+++ b/back/src/api/mesures/schemaRessourceModule.schema.ts
@@ -1,0 +1,5 @@
+import z from 'zod';
+
+export const schemaRessourceModule = z.strictObject({
+  idModule: z.string().regex(/\d+/),
+});

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -297,7 +297,7 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
       ressourceAvisMesure(configurationServeur),
       ressourcePriseEnCompte(configurationServeur)
     );
-    app.use('/api/modules/cyberdepart/mesures', ressourceMesuresDeModule(configurationServeur));
+    app.use('/api/modules/1/mesures', ressourceMesuresDeModule(configurationServeur));
     app.use('/module-cyberdepart', ressourcePagesJekyllConnectees(configurationServeur, 'module-cyberdepart'));
     app.use('/mesures/:id', ressourcePagesJekyllConnectees(configurationServeur, 'mesures'));
   }

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -16,7 +16,7 @@ import { ressourceGuides } from './guides/ressourceGuides';
 import { ressourceGuidesMemesCollections } from './guides/ressourceGuidesMemesCollections';
 import { ressourceAvisMesure } from './mesures/ressourceAvisMesure';
 import { ressourceMesure } from './mesures/ressourceMesure';
-import { ressourceMesuresDeModule } from './mesures/ressourceMesuresDeModule';
+import { ressourceModule } from './mesures/ressourceModule';
 import { ressourcePriseEnCompte } from './mesures/ressourcePriseEnCompte';
 import { ressourceDemandesAide } from './mon-aide-cyber/ressourceDemandesAide';
 import { ressourceExigencesNis2 } from './nis2/ressourceExigencesNis2';
@@ -297,7 +297,7 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
       ressourceAvisMesure(configurationServeur),
       ressourcePriseEnCompte(configurationServeur)
     );
-    app.use('/api/modules', ressourceMesuresDeModule(configurationServeur));
+    app.use('/api/modules', ressourceModule(configurationServeur));
     app.use('/module-cyberdepart', ressourcePagesJekyllConnectees(configurationServeur, 'module-cyberdepart'));
     app.use('/mesures/:id', ressourcePagesJekyllConnectees(configurationServeur, 'mesures'));
   }

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -297,7 +297,7 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
       ressourceAvisMesure(configurationServeur),
       ressourcePriseEnCompte(configurationServeur)
     );
-    app.use('/api/modules/1/mesures', ressourceMesuresDeModule(configurationServeur));
+    app.use('/api/modules', ressourceMesuresDeModule(configurationServeur));
     app.use('/module-cyberdepart', ressourcePagesJekyllConnectees(configurationServeur, 'module-cyberdepart'));
     app.use('/mesures/:id', ressourcePagesJekyllConnectees(configurationServeur, 'mesures'));
   }

--- a/back/src/entrepotModulePostgres.ts
+++ b/back/src/entrepotModulePostgres.ts
@@ -1,0 +1,20 @@
+import Knex from 'knex';
+import config from '../knexfile';
+import { EntrepôtModule } from './metier/EntrepotModule';
+import { Module } from './metier/module';
+
+export class EntrepôtModulePostgres implements EntrepôtModule {
+  knex: Knex.Knex;
+
+  constructor() {
+    this.knex = Knex(config);
+  }
+
+  async parId(id: number): Promise<Module | undefined> {
+    const moduleLu = await this.knex<{ id: number; nom: string }>('modules').where({ id }).first();
+    if (!moduleLu) {
+      return undefined;
+    }
+    return new Module(moduleLu.id, moduleLu.nom);
+  }
+}

--- a/back/src/entrepotModulePostgres.ts
+++ b/back/src/entrepotModulePostgres.ts
@@ -3,6 +3,8 @@ import config from '../knexfile';
 import { EntrepôtModule } from './metier/EntrepotModule';
 import { Module } from './metier/module';
 
+type ModulePersisté = { id: number; nom: string };
+
 export class EntrepôtModulePostgres implements EntrepôtModule {
   knex: Knex.Knex;
 
@@ -11,7 +13,7 @@ export class EntrepôtModulePostgres implements EntrepôtModule {
   }
 
   async parId(id: number): Promise<Module | undefined> {
-    const moduleLu = await this.knex<{ id: number; nom: string }>('modules').where({ id }).first();
+    const moduleLu = await this.knex<ModulePersisté>('modules').where({ id }).first();
     if (!moduleLu) {
       return undefined;
     }

--- a/back/src/infra/entrepotMesurePostgres.ts
+++ b/back/src/infra/entrepotMesurePostgres.ts
@@ -2,6 +2,7 @@ import Knex from 'knex';
 import config from '../../knexfile';
 import { EntrepotMesure } from '../metier/entrepotMesure';
 import { LienPourAllerPlusLoin, Mesure, type Risque } from '../metier/mesure';
+import { Module } from '../metier/module';
 import { EntrepotExigence } from '../metier/nis2/entrepotExigence';
 
 export type MesurePersistee = {
@@ -17,6 +18,7 @@ export type MesurePersistee = {
   risques: Risque[];
   liens: LienPourAllerPlusLoin[];
 };
+
 export class EntrepotMesurePostgres implements EntrepotMesure {
   knex: Knex.Knex;
   /**
@@ -41,6 +43,10 @@ export class EntrepotMesurePostgres implements EntrepotMesure {
     }
     await this.chargementEnCours;
     return [...this.cache.values()];
+  }
+
+  duModule(_module: Module): Promise<Mesure[]> {
+    throw new Error('Method not implemented.');
   }
 
   async parId(id: string): Promise<Mesure | undefined> {

--- a/back/src/infra/entrepotMesurePostgres.ts
+++ b/back/src/infra/entrepotMesurePostgres.ts
@@ -92,6 +92,11 @@ export class EntrepotMesurePostgres implements EntrepotMesure {
 
     const module = await this.entrepôtModule.parId(mesurePersistee.id_module);
 
+    if (!module) {
+      console.warn('Module de la mesure non trouvé !', mesurePersistee.id, mesurePersistee.id_module);
+      throw new Error('Module de la mesure non trouvé');
+    }
+
     return new Mesure(
       mesurePersistee.id,
       mesurePersistee.titre,
@@ -103,7 +108,7 @@ export class EntrepotMesurePostgres implements EntrepotMesure {
       mesurePersistee.risques,
       mesurePersistee.liens,
       exigences,
-      module!
+      module
     );
   }
 }

--- a/back/src/infra/entrepotMesurePostgres.ts
+++ b/back/src/infra/entrepotMesurePostgres.ts
@@ -1,6 +1,7 @@
 import Knex from 'knex';
 import config from '../../knexfile';
 import { EntrepotMesure } from '../metier/entrepotMesure';
+import { EntrepôtModule } from '../metier/EntrepotModule';
 import { LienPourAllerPlusLoin, Mesure, type Risque } from '../metier/mesure';
 import { Module } from '../metier/module';
 import { EntrepotExigence } from '../metier/nis2/entrepotExigence';
@@ -28,7 +29,10 @@ export class EntrepotMesurePostgres implements EntrepotMesure {
   private readonly cache: Map<Mesure['id'], Mesure> = new Map();
   private chargementEnCours: Promise<void> | null = null;
 
-  constructor(private readonly entrepotExigence: EntrepotExigence) {
+  constructor(
+    private readonly entrepotExigence: EntrepotExigence,
+    private readonly entrepôtModule: EntrepôtModule
+  ) {
     this.knex = Knex(config);
   }
 
@@ -45,8 +49,11 @@ export class EntrepotMesurePostgres implements EntrepotMesure {
     return [...this.cache.values()];
   }
 
-  duModule(_module: Module): Promise<Mesure[]> {
-    throw new Error('Method not implemented.');
+  async duModule(module: Module): Promise<Mesure[]> {
+    if (this.cache.size === 0) {
+      await this.tous();
+    }
+    return [...this.cache.values().filter((mesure) => mesure.module!.id === module.id)];
   }
 
   async parId(id: string): Promise<Mesure | undefined> {
@@ -57,7 +64,7 @@ export class EntrepotMesurePostgres implements EntrepotMesure {
   }
 
   private async chargerCache(): Promise<void> {
-    const mesuresLues = await this.knex<MesurePersistee>('mesures').where({ id_module: 1 });
+    const mesuresLues = await this.knex<MesurePersistee>('mesures');
     const mesures = await Promise.all(mesuresLues.map((m) => this.convertisEnMesure(m)));
     mesures.forEach((m) => this.cache.set(m.id, m));
   }
@@ -83,6 +90,8 @@ export class EntrepotMesurePostgres implements EntrepotMesure {
       })
       .filter((e) => !!e);
 
+    const module = await this.entrepôtModule.parId(mesurePersistee.id_module);
+
     return new Mesure(
       mesurePersistee.id,
       mesurePersistee.titre,
@@ -93,7 +102,8 @@ export class EntrepotMesurePostgres implements EntrepotMesure {
       mesurePersistee.ordre,
       mesurePersistee.risques,
       mesurePersistee.liens,
-      exigences
+      exigences,
+      module!
     );
   }
 }

--- a/back/src/metier/EntrepotModule.ts
+++ b/back/src/metier/EntrepotModule.ts
@@ -1,0 +1,5 @@
+import { Module } from './module';
+
+export interface EntrepôtModule {
+  parId(id: number): Promise<Module | undefined>;
+}

--- a/back/src/metier/entrepotMesure.ts
+++ b/back/src/metier/entrepotMesure.ts
@@ -1,7 +1,10 @@
 import { Mesure } from './mesure';
+import { Module } from './module';
 
 export interface EntrepotMesure {
   parId(id: string): Promise<Mesure | undefined>;
 
   tous(): Promise<Mesure[]>;
+
+  duModule(module: Module): Promise<Mesure[]>;
 }

--- a/back/src/metier/mesure.ts
+++ b/back/src/metier/mesure.ts
@@ -25,4 +25,13 @@ export class Mesure {
     readonly exigences: ExigenceNIS2[],
     readonly module: Module | null = null
   ) {}
+
+  rangDansSonModule = () => {
+    if (this.module === null) {
+      return -1;
+    }
+    return this.module.mesures.sort((a, b) => a.ordre - b.ordre).findIndex((m) => m.id === this.id);
+  };
+
+  positionDansSonModule = () => this.rangDansSonModule() + 1;
 }

--- a/back/src/metier/mesure.ts
+++ b/back/src/metier/mesure.ts
@@ -23,15 +23,10 @@ export class Mesure {
     readonly risques: Risque[],
     readonly liens: LienPourAllerPlusLoin[],
     readonly exigences: ExigenceNIS2[],
-    readonly module: Module | null = null
+    readonly module: Module
   ) {}
 
-  rangDansSonModule = () => {
-    if (this.module === null) {
-      return -1;
-    }
-    return this.module.mesures.sort((a, b) => a.ordre - b.ordre).findIndex((m) => m.id === this.id);
-  };
+  rangDansSonModule = () => this.module.mesures.sort((a, b) => a.ordre - b.ordre).findIndex((m) => m.id === this.id);
 
   positionDansSonModule = () => this.rangDansSonModule() + 1;
 }

--- a/back/src/metier/mesure.ts
+++ b/back/src/metier/mesure.ts
@@ -1,3 +1,4 @@
+import { Module } from './module';
 import { ExigenceNIS2 } from './nis2/exigence';
 
 export type Risque = {
@@ -21,6 +22,7 @@ export class Mesure {
     readonly ordre: number,
     readonly risques: Risque[],
     readonly liens: LienPourAllerPlusLoin[],
-    readonly exigences: ExigenceNIS2[]
+    readonly exigences: ExigenceNIS2[],
+    readonly module: Module | null = null
   ) {}
 }

--- a/back/src/metier/module.ts
+++ b/back/src/metier/module.ts
@@ -1,0 +1,6 @@
+export class Module {
+  constructor(
+    readonly id: number,
+    readonly nom: string
+  ) {}
+}

--- a/back/src/metier/module.ts
+++ b/back/src/metier/module.ts
@@ -8,7 +8,7 @@ export class Module {
     readonly nom: string
   ) {}
 
-  cibleDéblocageBadgeCyberdépart() {
-    return Math.floor(this.mesures.length * 0.8);
-  }
+  cibleDéblocageBadgeCyberdépart = () => Math.floor(this.mesures.length * 0.8);
+
+  nombreDeMesures = () => this.mesures.length;
 }

--- a/back/src/metier/module.ts
+++ b/back/src/metier/module.ts
@@ -1,6 +1,14 @@
+import { Mesure } from './mesure';
+
 export class Module {
+  mesures: Mesure[] = [];
+
   constructor(
     readonly id: number,
     readonly nom: string
   ) {}
+
+  cibleDéblocageBadgeCyberdépart() {
+    return Math.floor(this.mesures.length * 0.8);
+  }
 }

--- a/back/src/metier/utilisateur.ts
+++ b/back/src/metier/utilisateur.ts
@@ -6,6 +6,7 @@ import { AdaptateurHachage } from '../infra/adaptateurHachage';
 import { AdaptateurRechercheEntreprise } from '../infra/adaptateurRechercheEntreprise';
 import { EntrepotPriseEnCompte } from './entrepotPriseEnCompte';
 import { Mesure } from './mesure';
+import { Module } from './module';
 import { PriseEnCompte } from './PriseEnCompte';
 
 export type Role = 'GESTION_GUIDES';
@@ -133,21 +134,21 @@ export class Utilisateur {
 
   async prendEnCompte(
     mesure: Mesure,
-    taille: number,
     rang: number,
     entrepotPriseEnCompte: EntrepotPriseEnCompte,
-    busEvenements: BusEvenements
+    busEvenements: BusEvenements,
+    module: Module
   ) {
     if (this.estPriseEnCompte(mesure)) {
       return;
     }
     await entrepotPriseEnCompte.ajoute(new PriseEnCompte(this, mesure));
-    await busEvenements.publie(new MesurePriseEnCompte(this.emailHache(), mesure.id, taille, rang + 1));
+    await busEvenements.publie(new MesurePriseEnCompte(this.emailHache(), mesure.id, module.mesures.length, rang + 1));
     this.mesuresPrisesEnCompte.push(mesure);
-    if (this.mesuresPrisesEnCompte.length === taille) {
+    if (this.mesuresPrisesEnCompte.length === module.mesures.length) {
       await busEvenements.publie(new ModuleTermine(this.emailHache(), 1, 'Cyberdépart'));
     }
-    const cibleBadgeCyberdépart = Math.floor(taille * 0.8);
+    const cibleBadgeCyberdépart = module.cibleDéblocageBadgeCyberdépart();
     if (this.mesuresPrisesEnCompte.length === cibleBadgeCyberdépart) {
       await busEvenements.publie(new BadgeCyberdépartDébloqué(this.emailHache()));
     }

--- a/back/src/metier/utilisateur.ts
+++ b/back/src/metier/utilisateur.ts
@@ -134,7 +134,6 @@ export class Utilisateur {
 
   async prendEnCompte(
     mesure: Mesure,
-    rang: number,
     entrepotPriseEnCompte: EntrepotPriseEnCompte,
     busEvenements: BusEvenements,
     module: Module
@@ -143,9 +142,11 @@ export class Utilisateur {
       return;
     }
     await entrepotPriseEnCompte.ajoute(new PriseEnCompte(this, mesure));
-    await busEvenements.publie(new MesurePriseEnCompte(this.emailHache(), mesure.id, module.mesures.length, rang + 1));
+    await busEvenements.publie(
+      new MesurePriseEnCompte(this.emailHache(), mesure.id, module.nombreDeMesures(), mesure.positionDansSonModule())
+    );
     this.mesuresPrisesEnCompte.push(mesure);
-    if (this.mesuresPrisesEnCompte.length === module.mesures.length) {
+    if (this.mesuresPrisesEnCompte.length === module.nombreDeMesures()) {
       await busEvenements.publie(new ModuleTermine(this.emailHache(), 1, 'Cyberdépart'));
     }
     const cibleBadgeCyberdépart = module.cibleDéblocageBadgeCyberdépart();

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -70,7 +70,9 @@ const entrepotExigence: EntrepotExigence = new EntrepotExigenceGrist({
   adaptateurEnvironnement,
 });
 
-const entrepotMesure: EntrepotMesure = new EntrepotMesurePostgres(entrepotExigence);
+const entrepôtModule = new EntrepôtModulePostgres();
+
+const entrepotMesure: EntrepotMesure = new EntrepotMesurePostgres(entrepotExigence, entrepôtModule);
 
 const entrepotUtilisateur = new EntrepotUtilisateurMPAPostgres({
   adaptateurProfilAnssi,
@@ -79,14 +81,13 @@ const entrepotUtilisateur = new EntrepotUtilisateurMPAPostgres({
   adaptateurHachage,
   entrepotMesure,
 });
+
 const entrepotResultatTest = new EntrepotResultatTestPostgres({
   adaptateurHachage,
   entrepotUtilisateur,
 });
 
 const entrepotPriseEnCompte = new EntrepotPriseEnComptePostgres(adaptateurHachage, entrepotMesure);
-
-const entrepôtModule = new EntrepôtModulePostgres();
 
 const messagerieInstantanee = messagerieMattermost({ adaptateurEnvironnement });
 

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -1,5 +1,4 @@
 import { CmsCrisp } from '@lab-anssi/lib';
-import axiosInstance from './infra/axiosInstance';
 import { adaptateurJWT } from './api/adaptateurJWT';
 import { fournisseurChemin } from './api/fournisseurChemin';
 import { fabriqueMiddleware } from './api/middleware';
@@ -7,6 +6,7 @@ import { creeServeur } from './api/msc';
 import { adaptateurOIDC } from './api/oidc/adaptateurOIDC';
 import { BusEvenements } from './bus/busEvenements';
 import { cableTousLesAbonnes } from './bus/cablage';
+import { EntrepôtModulePostgres } from './entrepotModulePostgres';
 import { adaptateurCellar } from './infra/adaptateurCellar';
 import { fabriqueAdaptateurChiffrement } from './infra/adaptateurChiffrement';
 import { fabriqueAdaptateurEmail } from './infra/adaptateurEmailBrevo';
@@ -18,6 +18,7 @@ import { fabriqueAdaptateurJournal } from './infra/adaptateurJournal';
 import { fabriqueAdaptateurMonAideCyber } from './infra/adaptateurMonAideCyber';
 import { fabriqueAdaptateurProfilAnssi } from './infra/adaptateurProfilAnssi';
 import { fabriqueAdaptateurRechercheEntreprise } from './infra/adaptateurRechercheEntreprise';
+import axiosInstance from './infra/axiosInstance';
 import { EntrepotFavoriPostgres } from './infra/entrepotFavoriPostgres';
 import { EntrepotFinancementGrist } from './infra/entrepotFinancementGrist';
 import { EntrepotGuideGrist } from './infra/entrepotGuideGrist';
@@ -84,6 +85,8 @@ const entrepotResultatTest = new EntrepotResultatTestPostgres({
 });
 
 const entrepotPriseEnCompte = new EntrepotPriseEnComptePostgres(adaptateurHachage, entrepotMesure);
+
+const entrepôtModule = new EntrepôtModulePostgres();
 
 const messagerieInstantanee = messagerieMattermost({ adaptateurEnvironnement });
 
@@ -163,6 +166,7 @@ serviceCoherenceSecretsHachage
       entrepotExigence,
       entrepotMesure,
       entrepotPriseEnCompte,
+      entrepôtModule,
       cellar,
       serviceSanteGuides,
       adaptateurEmail,

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -25,6 +25,7 @@ import { EntrepotPriseEnCompteMemoire } from '../persistance/EntrepotPriseEnComp
 import { EntrepotResultatTestMemoire } from '../persistance/entrepotResultatTestMemoire';
 import { EntrepotSessionDeGroupeMemoire } from '../persistance/EntrepotSessionDeGroupeMemoire';
 import { EntrepotUtilisateurMemoire } from '../persistance/entrepotUtilisateurMemoire';
+import { EntrepôtModuleMémoire } from '../persistance/EntrepôtModuleMémoire';
 
 export const fauxFournisseurDeChemin: FournisseurChemin = {
   cheminPageJekyll: (_: string) => join(process.cwd(), 'tests', 'ressources', 'factice.html'),
@@ -264,6 +265,7 @@ export const configurationDeTestDuServeur: ConfigurationServeur = {
   entrepotExigence: new EntrepotExigenceMemoire(),
   entrepotMesure: new EntrepotMesureMemoire(),
   entrepotPriseEnCompte: new EntrepotPriseEnCompteMemoire(),
+  entrepôtModule: new EntrepôtModuleMémoire(),
   entrepotUtilisateur,
   fournisseurChemin: fauxFournisseurDeChemin,
   generateurCodeSessionDeGroupe: fauxGenerateurCodeSessionDeGroupe,

--- a/back/tests/api/mesures/constructeurDeMesure.ts
+++ b/back/tests/api/mesures/constructeurDeMesure.ts
@@ -1,4 +1,5 @@
-import { Mesure, Risque, LienPourAllerPlusLoin } from '../../../src/metier/mesure';
+import { LienPourAllerPlusLoin, Mesure, Risque } from '../../../src/metier/mesure';
+import { Module } from '../../../src/metier/module';
 import { ExigenceNIS2 } from '../../../src/metier/nis2/exigence';
 
 export class ConstructeurDeMesure {
@@ -12,6 +13,7 @@ export class ConstructeurDeMesure {
   private readonly risques: Risque[] = [];
   private readonly liens: LienPourAllerPlusLoin[] = [];
   private readonly exigences: ExigenceNIS2[] = [];
+  private module: Module | null = null;
 
   avecLId(id: string) {
     this.id = id;
@@ -63,6 +65,11 @@ export class ConstructeurDeMesure {
     return this;
   }
 
+  duModule(module: Module) {
+    this.module = module;
+    return this;
+  }
+
   construis() {
     return new Mesure(
       this.id,
@@ -74,7 +81,8 @@ export class ConstructeurDeMesure {
       this.ordre,
       this.risques,
       this.liens,
-      this.exigences
+      this.exigences,
+      this.module
     );
   }
 }

--- a/back/tests/api/mesures/constructeurDeMesure.ts
+++ b/back/tests/api/mesures/constructeurDeMesure.ts
@@ -1,6 +1,7 @@
 import { LienPourAllerPlusLoin, Mesure, Risque } from '../../../src/metier/mesure';
 import { Module } from '../../../src/metier/module';
 import { ExigenceNIS2 } from '../../../src/metier/nis2/exigence';
+import { moduleCyberdépart } from '../objetsPretsALEmploi';
 
 export class ConstructeurDeMesure {
   private id: string = '';
@@ -13,7 +14,7 @@ export class ConstructeurDeMesure {
   private readonly risques: Risque[] = [];
   private readonly liens: LienPourAllerPlusLoin[] = [];
   private readonly exigences: ExigenceNIS2[] = [];
-  private module: Module | null = null;
+  private module: Module = moduleCyberdépart;
 
   avecLId(id: string) {
     this.id = id;

--- a/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
+++ b/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
@@ -5,11 +5,13 @@ import request from 'supertest';
 import { creeServeur } from '../../../src/api/msc';
 import { AdaptateurEnvironnement } from '../../../src/infra/adaptateurEnvironnement';
 import { EntrepotUtilisateur } from '../../../src/metier/entrepotUtilisateur';
+import { Module } from '../../../src/metier/module';
 import { EntrepotMesureMemoire } from '../../persistance/entrepotMesureMemoire';
 import { EntrepotUtilisateurMemoire } from '../../persistance/entrepotUtilisateurMemoire';
+import { EntrepôtModuleMémoire } from '../../persistance/EntrepôtModuleMémoire';
 import { encodeSession } from '../cookie';
 import { configurationDeTestDuServeur, fauxAdaptateurEnvironnement } from '../fauxObjets';
-import { jeanneDupont, mesureAuthentA2Etapes } from '../objetsPretsALEmploi';
+import { jeanneDupont, mesureAuthentA2Etapes, moduleCyberdépart } from '../objetsPretsALEmploi';
 import { mesureDeTest } from './constructeurDeMesure';
 import { utilisateurDeTest } from './constructeurDUtilisateur';
 
@@ -19,6 +21,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
     let entrepotMesure: EntrepotMesureMemoire;
     let adaptateurEnvironnement: AdaptateurEnvironnement;
     let entrepotUtilisateur: EntrepotUtilisateur;
+    let entrepôtModule: EntrepôtModuleMémoire;
     const cookieJeanneDupont = encodeSession({ email: jeanneDupont.email, token: 'valide' });
 
     beforeEach(async () => {
@@ -27,10 +30,13 @@ describe('La ressource des mesures de sécurité d’un module', () => {
       };
       entrepotMesure = new EntrepotMesureMemoire();
       entrepotUtilisateur = new EntrepotUtilisateurMemoire();
+      entrepôtModule = new EntrepôtModuleMémoire();
+      await entrepôtModule.ajoute(moduleCyberdépart);
       serveur = creeServeur({
         ...configurationDeTestDuServeur,
         entrepotMesure,
         entrepotUtilisateur,
+        entrepôtModule,
         adaptateurEnvironnement,
       });
       await entrepotUtilisateur.ajoute(jeanneDupont);
@@ -61,8 +67,12 @@ describe('La ressource des mesures de sécurité d’un module', () => {
     });
 
     it('trie les mesures par ordre', async () => {
-      await entrepotMesure.ajoute(mesureDeTest().avecLId('MES1').avecLOrdre(30).construis());
-      await entrepotMesure.ajoute(mesureDeTest().avecLId('MES2').avecLOrdre(10).construis());
+      await entrepotMesure.ajoute(
+        mesureDeTest().avecLId('MES1').duModule(moduleCyberdépart).avecLOrdre(30).construis()
+      );
+      await entrepotMesure.ajoute(
+        mesureDeTest().avecLId('MES2').duModule(moduleCyberdépart).avecLOrdre(10).construis()
+      );
 
       const { body } = await getMesuresConnecte();
 
@@ -100,12 +110,24 @@ describe('La ressource des mesures de sécurité d’un module', () => {
       const cookie = encodeSession({ email: unUtilisateurAvecUnePriseEnCompte.email, token: 'valide' });
       await entrepotUtilisateur.ajoute(unUtilisateurAvecUnePriseEnCompte);
       await entrepotMesure.ajoute(mesureAuth5);
-      await entrepotMesure.ajoute(mesureDeTest().avecLId('MES1').avecLOrdre(15).construis());
+      await entrepotMesure.ajoute(
+        mesureDeTest().avecLId('MES1').avecLOrdre(15).duModule(moduleCyberdépart).construis()
+      );
 
       const { body } = await request(serveur).get('/api/modules/1/mesures').set('Cookie', cookie);
 
       assert.equal(body[0].estPriseEnCompte, true);
       assert.equal(body[1].estPriseEnCompte, false);
+    });
+
+    it('ne renvoie que les mesures du module demandé', async () => {
+      const module = new Module(4, 'Perte de maîtrise de son entité');
+      await entrepôtModule.ajoute(module);
+      await entrepotMesure.ajoute(mesureDeTest().duModule(module).construis());
+
+      const { body } = await getMesuresConnecte();
+
+      assert.equal(body.length, 0);
     });
   });
 });

--- a/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
+++ b/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
@@ -62,8 +62,8 @@ describe('La ressource des mesures de sécurité d’un module', () => {
 
       const { body } = await getMesuresCyberdépartConnecté();
 
-      assert.equal(body.length, 1);
-      assert.equal(body[0].id, 'AUTH.5');
+      assert.equal(body.mesures.length, 1);
+      assert.equal(body.mesures[0].id, 'AUTH.5');
     });
 
     it('trie les mesures par ordre', async () => {
@@ -76,8 +76,8 @@ describe('La ressource des mesures de sécurité d’un module', () => {
 
       const { body } = await getMesuresCyberdépartConnecté();
 
-      assert.equal(body[0].id, 'MES2');
-      assert.equal(body[1].id, 'MES1');
+      assert.equal(body.mesures[0].id, 'MES2');
+      assert.equal(body.mesures[1].id, 'MES1');
     });
 
     it('réponds 404 si la fonctionnalité est désactivée', async () => {
@@ -116,8 +116,8 @@ describe('La ressource des mesures de sécurité d’un module', () => {
 
       const { body } = await request(serveur).get('/api/modules/1/mesures').set('Cookie', cookie);
 
-      assert.equal(body[0].estPriseEnCompte, true);
-      assert.equal(body[1].estPriseEnCompte, false);
+      assert.equal(body.mesures[0].estPriseEnCompte, true);
+      assert.equal(body.mesures[1].estPriseEnCompte, false);
     });
 
     it('ne renvoie que les mesures du module demandé', async () => {
@@ -127,7 +127,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
 
       const { body } = await getMesuresCyberdépartConnecté();
 
-      assert.equal(body.length, 0);
+      assert.equal(body.mesures.length, 0);
     });
 
     it('réponds 404 si le module est inconnu', async () => {

--- a/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
+++ b/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
@@ -37,7 +37,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
     });
 
     const getMesuresConnecte = async () =>
-      request(serveur).get('/api/modules/cyberdepart/mesures').set('Cookie', cookieJeanneDupont);
+      request(serveur).get('/api/modules/1/mesures').set('Cookie', cookieJeanneDupont);
 
     it('réponds 200', async () => {
       const reponse = await getMesuresConnecte();
@@ -46,7 +46,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
     });
 
     it('réponds 401 si l’utilisateur n’est pas connecté', async () => {
-      const reponse = await request(serveur).get('/api/modules/cyberdepart/mesures');
+      const reponse = await request(serveur).get('/api/modules/1/mesures');
 
       assert.equal(reponse.status, 401);
     });
@@ -88,7 +88,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
         entrepotMesure,
         adaptateurEnvironnement,
       });
-      const reponse = await request(serveurSansLaRessource).get('/api/modules/cyberdepart/mesures');
+      const reponse = await request(serveurSansLaRessource).get('/api/modules/1/mesures');
 
       assert.equal(reponse.status, 404);
     });
@@ -102,7 +102,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
       await entrepotMesure.ajoute(mesureAuth5);
       await entrepotMesure.ajoute(mesureDeTest().avecLId('MES1').avecLOrdre(15).construis());
 
-      const { body } = await request(serveur).get('/api/modules/cyberdepart/mesures').set('Cookie', cookie);
+      const { body } = await request(serveur).get('/api/modules/1/mesures').set('Cookie', cookie);
 
       assert.equal(body[0].estPriseEnCompte, true);
       assert.equal(body[1].estPriseEnCompte, false);

--- a/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
+++ b/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
@@ -43,7 +43,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
     });
 
     const getMesuresCyberdépartConnecté = async () =>
-      request(serveur).get('/api/modules/1/mesures').set('Cookie', cookieJeanneDupont);
+      request(serveur).get('/api/modules/1').set('Cookie', cookieJeanneDupont);
 
     it('réponds 200', async () => {
       const reponse = await getMesuresCyberdépartConnecté();
@@ -52,7 +52,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
     });
 
     it('réponds 401 si l’utilisateur n’est pas connecté', async () => {
-      const reponse = await request(serveur).get('/api/modules/1/mesures');
+      const reponse = await request(serveur).get('/api/modules/1');
 
       assert.equal(reponse.status, 401);
     });
@@ -98,7 +98,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
         entrepotMesure,
         adaptateurEnvironnement,
       });
-      const reponse = await request(serveurSansLaRessource).get('/api/modules/1/mesures');
+      const reponse = await request(serveurSansLaRessource).get('/api/modules/1');
 
       assert.equal(reponse.status, 404);
     });
@@ -114,7 +114,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
         mesureDeTest().avecLId('MES1').avecLOrdre(15).duModule(moduleCyberdépart).construis()
       );
 
-      const { body } = await request(serveur).get('/api/modules/1/mesures').set('Cookie', cookie);
+      const { body } = await request(serveur).get('/api/modules/1').set('Cookie', cookie);
 
       assert.equal(body.mesures[0].estPriseEnCompte, true);
       assert.equal(body.mesures[1].estPriseEnCompte, false);
@@ -131,7 +131,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
     });
 
     it('réponds 404 si le module est inconnu', async () => {
-      const reponse = await request(serveur).get('/api/modules/199/mesures').set('Cookie', cookieJeanneDupont);
+      const reponse = await request(serveur).get('/api/modules/199').set('Cookie', cookieJeanneDupont);
 
       assert.equal(reponse.status, 404);
     });

--- a/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
+++ b/back/tests/api/mesures/ressourceMesuresDeModule.spec.ts
@@ -42,11 +42,11 @@ describe('La ressource des mesures de sécurité d’un module', () => {
       await entrepotUtilisateur.ajoute(jeanneDupont);
     });
 
-    const getMesuresConnecte = async () =>
+    const getMesuresCyberdépartConnecté = async () =>
       request(serveur).get('/api/modules/1/mesures').set('Cookie', cookieJeanneDupont);
 
     it('réponds 200', async () => {
-      const reponse = await getMesuresConnecte();
+      const reponse = await getMesuresCyberdépartConnecté();
 
       assert.equal(reponse.status, 200);
     });
@@ -60,7 +60,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
     it('renvoie la liste des mesures', async () => {
       await entrepotMesure.ajoute(mesureAuthentA2Etapes());
 
-      const { body } = await getMesuresConnecte();
+      const { body } = await getMesuresCyberdépartConnecté();
 
       assert.equal(body.length, 1);
       assert.equal(body[0].id, 'AUTH.5');
@@ -74,7 +74,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
         mesureDeTest().avecLId('MES2').duModule(moduleCyberdépart).avecLOrdre(10).construis()
       );
 
-      const { body } = await getMesuresConnecte();
+      const { body } = await getMesuresCyberdépartConnecté();
 
       assert.equal(body[0].id, 'MES2');
       assert.equal(body[1].id, 'MES1');
@@ -125,9 +125,15 @@ describe('La ressource des mesures de sécurité d’un module', () => {
       await entrepôtModule.ajoute(module);
       await entrepotMesure.ajoute(mesureDeTest().duModule(module).construis());
 
-      const { body } = await getMesuresConnecte();
+      const { body } = await getMesuresCyberdépartConnecté();
 
       assert.equal(body.length, 0);
+    });
+
+    it('réponds 404 si le module est inconnu', async () => {
+      const reponse = await request(serveur).get('/api/modules/199/mesures').set('Cookie', cookieJeanneDupont);
+
+      assert.equal(reponse.status, 404);
     });
   });
 });

--- a/back/tests/api/mesures/ressourceModule.spec.ts
+++ b/back/tests/api/mesures/ressourceModule.spec.ts
@@ -145,5 +145,11 @@ describe('La ressource d’un module', () => {
 
       assert.equal(body.cibleBadge, 4);
     });
+
+    it('valide le type du paramètre de la requête', async () => {
+      const reponse = await request(serveur).get('/api/modules/pas-un-nombre').set('Cookie', cookieJeanneDupont);
+
+      assert.equal(reponse.status, 404);
+    });
   });
 });

--- a/back/tests/api/mesures/ressourceModule.spec.ts
+++ b/back/tests/api/mesures/ressourceModule.spec.ts
@@ -135,5 +135,15 @@ describe('La ressource d’un module', () => {
 
       assert.equal(reponse.status, 404);
     });
+
+    it('fournis la cible de déblocage du bagde cyberdépart', async () => {
+      for (let i = 0; i < 5; i++) {
+        await entrepotMesure.ajoute(mesureDeTest().duModule(moduleCyberdépart).construis());
+      }
+
+      const { body } = await getModuleCyberdépartConnecté();
+
+      assert.equal(body.cibleBadge, 4);
+    });
   });
 });

--- a/back/tests/api/mesures/ressourceModule.spec.ts
+++ b/back/tests/api/mesures/ressourceModule.spec.ts
@@ -15,7 +15,7 @@ import { jeanneDupont, mesureAuthentA2Etapes, moduleCyberdépart } from '../obje
 import { mesureDeTest } from './constructeurDeMesure';
 import { utilisateurDeTest } from './constructeurDUtilisateur';
 
-describe('La ressource des mesures de sécurité d’un module', () => {
+describe('La ressource d’un module', () => {
   describe('sur requête GET', () => {
     let serveur: Express;
     let entrepotMesure: EntrepotMesureMemoire;
@@ -42,11 +42,11 @@ describe('La ressource des mesures de sécurité d’un module', () => {
       await entrepotUtilisateur.ajoute(jeanneDupont);
     });
 
-    const getMesuresCyberdépartConnecté = async () =>
+    const getModuleCyberdépartConnecté = async () =>
       request(serveur).get('/api/modules/1').set('Cookie', cookieJeanneDupont);
 
     it('réponds 200', async () => {
-      const reponse = await getMesuresCyberdépartConnecté();
+      const reponse = await getModuleCyberdépartConnecté();
 
       assert.equal(reponse.status, 200);
     });
@@ -60,7 +60,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
     it('renvoie la liste des mesures', async () => {
       await entrepotMesure.ajoute(mesureAuthentA2Etapes());
 
-      const { body } = await getMesuresCyberdépartConnecté();
+      const { body } = await getModuleCyberdépartConnecté();
 
       assert.equal(body.mesures.length, 1);
       assert.equal(body.mesures[0].id, 'AUTH.5');
@@ -74,7 +74,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
         mesureDeTest().avecLId('MES2').duModule(moduleCyberdépart).avecLOrdre(10).construis()
       );
 
-      const { body } = await getMesuresCyberdépartConnecté();
+      const { body } = await getModuleCyberdépartConnecté();
 
       assert.equal(body.mesures[0].id, 'MES2');
       assert.equal(body.mesures[1].id, 'MES1');
@@ -125,7 +125,7 @@ describe('La ressource des mesures de sécurité d’un module', () => {
       await entrepôtModule.ajoute(module);
       await entrepotMesure.ajoute(mesureDeTest().duModule(module).construis());
 
-      const { body } = await getMesuresCyberdépartConnecté();
+      const { body } = await getModuleCyberdépartConnecté();
 
       assert.equal(body.mesures.length, 0);
     });

--- a/back/tests/api/mesures/ressourcePriseEnCompte.spec.ts
+++ b/back/tests/api/mesures/ressourcePriseEnCompte.spec.ts
@@ -5,15 +5,16 @@ import request from 'supertest';
 import { creeServeur } from '../../../src/api/msc';
 import { MesurePriseEnCompte } from '../../../src/bus/evenements/mesurePriseEnCompte';
 import { EntrepotUtilisateur } from '../../../src/metier/entrepotUtilisateur';
+import { Module } from '../../../src/metier/module';
+import { Utilisateur } from '../../../src/metier/utilisateur';
 import { fabriqueBusPourLesTests, MockBusEvenement } from '../../bus/busPourLesTests';
 import { EntrepotMesureMemoire } from '../../persistance/entrepotMesureMemoire';
 import { EntrepotPriseEnCompteMemoire } from '../../persistance/EntrepotPriseEnCompteMemoire';
 import { EntrepotUtilisateurMemoire } from '../../persistance/entrepotUtilisateurMemoire';
 import { encodeSession } from '../cookie';
 import { configurationDeTestDuServeur } from '../fauxObjets';
-import { mesureAuthentA2Etapes } from '../objetsPretsALEmploi';
+import { mesureAuthentA2Etapes, moduleCyberdépart } from '../objetsPretsALEmploi';
 import { mesureDeTest } from './constructeurDeMesure';
-import { Utilisateur } from '../../../src/metier/utilisateur';
 import { utilisateurDeTest } from './constructeurDUtilisateur';
 
 describe("La ressource de prise en compte d'une mesure", () => {
@@ -81,8 +82,12 @@ describe("La ressource de prise en compte d'une mesure", () => {
       });
 
       it('publie un événement de prise en compte', async () => {
-        await entrepotMesure.ajoute(mesureDeTest().avecLId('AUTH.1').avecLOrdre(1).construis());
-        await entrepotMesure.ajoute(mesureDeTest().avecLId('AUTH.20').avecLOrdre(20).construis());
+        await entrepotMesure.ajoute(
+          mesureDeTest().avecLId('AUTH.1').avecLOrdre(1).duModule(moduleCyberdépart).construis()
+        );
+        await entrepotMesure.ajoute(
+          mesureDeTest().avecLId('AUTH.20').avecLOrdre(20).duModule(moduleCyberdépart).construis()
+        );
 
         await putPriseEnCompteConnecte();
 
@@ -92,6 +97,15 @@ describe("La ressource de prise en compte d'une mesure", () => {
         assert.equal(evenement!.emailHache, 'utilisateur@mail.com-hache');
         assert.equal(evenement!.nombreDeMesures, 3);
         assert.equal(evenement!.position, 2);
+      });
+
+      it('ne compte pas les mesures des autres modules dans l’événement', async () => {
+        await entrepotMesure.ajoute(mesureDeTest().duModule(new Module(2, 'test')).construis());
+
+        await putPriseEnCompteConnecte();
+
+        const evenement = busEvenements.recupereEvenement(MesurePriseEnCompte);
+        assert.equal(evenement!.nombreDeMesures, 1);
       });
     });
   });

--- a/back/tests/api/objetsPretsALEmploi.ts
+++ b/back/tests/api/objetsPretsALEmploi.ts
@@ -1,5 +1,6 @@
 import { Financement } from '../../src/metier/financement';
 import { Guide } from '../../src/metier/guide';
+import { Module } from '../../src/metier/module';
 import { ExigenceNIS2 } from '../../src/metier/nis2/exigence';
 import { Utilisateur } from '../../src/metier/utilisateur';
 import { fauxAdaptateurHachage, fauxAdaptateurRechercheEntreprise } from './fauxObjets';
@@ -113,6 +114,8 @@ export const guidePublieDemain = () =>
     besoins: ['SECURISER'],
   });
 
+export const moduleCyberdépart = new Module(1, 'Cyberdépart');
+
 export const mesureAuthentA2Etapes = () => {
   const exigence = new ExigenceNIS2({
     reference: '10.B.5-EI/EE',
@@ -163,5 +166,6 @@ Ainsi, même si un mot de passe est volé ou deviné, l’accès au compte reste
       'https://cyber.gouv.fr/publications/recommandations-relatives-lauthentification-multifacteur-et-aux-mots-de-passe'
     )
     .avecUneExigence(exigence)
+    .duModule(moduleCyberdépart)
     .construis();
 };

--- a/back/tests/metier/utilisateur.spec.ts
+++ b/back/tests/metier/utilisateur.spec.ts
@@ -1,17 +1,17 @@
 import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
+import { BadgeCyberdépartDébloqué } from '../../src/bus/evenements/badgeCyberdepartDebloque';
+import { MesurePriseEnCompte } from '../../src/bus/evenements/mesurePriseEnCompte';
+import { ModuleTermine } from '../../src/bus/evenements/moduleTermine';
 import { AdaptateurRechercheEntreprise } from '../../src/infra/adaptateurRechercheEntreprise';
+import { EntrepotPriseEnCompte } from '../../src/metier/entrepotPriseEnCompte';
 import { Organisation, Utilisateur } from '../../src/metier/utilisateur';
 import { fauxAdaptateurHachage, fauxAdaptateurRechercheEntreprise } from '../api/fauxObjets';
-import { utilisateurDeTest } from '../api/mesures/constructeurDUtilisateur';
-import { mesureAuthentA2Etapes } from '../api/objetsPretsALEmploi';
-import { EntrepotPriseEnCompte } from '../../src/metier/entrepotPriseEnCompte';
-import { EntrepotPriseEnCompteMemoire } from '../persistance/EntrepotPriseEnCompteMemoire';
-import { fabriqueBusPourLesTests, MockBusEvenement } from '../bus/busPourLesTests';
-import { ModuleTermine } from '../../src/bus/evenements/moduleTermine';
-import { MesurePriseEnCompte } from '../../src/bus/evenements/mesurePriseEnCompte';
 import { mesureDeTest } from '../api/mesures/constructeurDeMesure';
-import { BadgeCyberdépartDébloqué } from '../../src/bus/evenements/badgeCyberdepartDebloque';
+import { utilisateurDeTest } from '../api/mesures/constructeurDUtilisateur';
+import { mesureAuthentA2Etapes, moduleCyberdépart } from '../api/objetsPretsALEmploi';
+import { fabriqueBusPourLesTests, MockBusEvenement } from '../bus/busPourLesTests';
+import { EntrepotPriseEnCompteMemoire } from '../persistance/EntrepotPriseEnCompteMemoire';
 
 describe("L'utilisateur", () => {
   const infosUtilisateur = {
@@ -170,7 +170,8 @@ describe("L'utilisateur", () => {
     });
 
     it('publie un événement de completion quand toutes les mesures du module sont prises en compte', async () => {
-      await utilisateurDeParcours.prendEnCompte(mesure, 1, 1, entrepotPriseEnCompte, busEvenements);
+      moduleCyberdépart.mesures = [mesureDeTest().construis()];
+      await utilisateurDeParcours.prendEnCompte(mesure, 1, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
       busEvenements.aRecuUnEvenement(ModuleTermine);
       const evenement = busEvenements.recupereEvenement(ModuleTermine);
@@ -181,14 +182,22 @@ describe("L'utilisateur", () => {
     });
 
     it("ne publie pas d'événement de completion si toutes les mesures du module ne sont pas prises en compte", async () => {
-      await utilisateurDeParcours.prendEnCompte(mesure, 2, 1, entrepotPriseEnCompte, busEvenements);
+      moduleCyberdépart.mesures = [mesureDeTest().construis(), mesureDeTest().construis()];
+
+      await utilisateurDeParcours.prendEnCompte(mesure, 2, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
       busEvenements.naPasRecuDEvenement(ModuleTermine);
     });
 
     it("ignore la prise en compte d'une mesure déjà prise en compte", async () => {
-      await utilisateurDeParcours.prendEnCompte(mesure, 2, 1, entrepotPriseEnCompte, fabriqueBusPourLesTests());
-      await utilisateurDeParcours.prendEnCompte(mesure, 2, 1, entrepotPriseEnCompte, busEvenements);
+      await utilisateurDeParcours.prendEnCompte(
+        mesure,
+        2,
+        entrepotPriseEnCompte,
+        fabriqueBusPourLesTests(),
+        moduleCyberdépart
+      );
+      await utilisateurDeParcours.prendEnCompte(mesure, 2, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
       assert.equal(utilisateurDeParcours.mesuresPrisesEnCompte.length, 1);
       busEvenements.naPasRecuDEvenement(ModuleTermine);
@@ -202,7 +211,14 @@ describe("L'utilisateur", () => {
           mesureDeTest().avecLId('mes2').construis(),
           mesureDeTest().avecLId('mes3').construis(),
         ];
-        await utilisateurDeParcours.prendEnCompte(mesure, 5, 1, entrepotPriseEnCompte, busEvenements);
+        moduleCyberdépart.mesures = [
+          mesureDeTest().construis(),
+          mesureDeTest().construis(),
+          mesureDeTest().construis(),
+          mesureDeTest().construis(),
+          mesureDeTest().construis(),
+        ];
+        await utilisateurDeParcours.prendEnCompte(mesure, 5, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
         busEvenements.aRecuUnEvenement(BadgeCyberdépartDébloqué);
       });
@@ -215,7 +231,7 @@ describe("L'utilisateur", () => {
           mesureDeTest().avecLId('mes4').construis(),
         ];
 
-        await utilisateurDeParcours.prendEnCompte(mesure, 5, 1, entrepotPriseEnCompte, busEvenements);
+        await utilisateurDeParcours.prendEnCompte(mesure, 5, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
         busEvenements.naPasRecuDEvenement(BadgeCyberdépartDébloqué);
       });
@@ -226,7 +242,7 @@ describe("L'utilisateur", () => {
           mesureDeTest().avecLId('mes2').construis(),
         ];
 
-        await utilisateurDeParcours.prendEnCompte(mesure, 5, 1, entrepotPriseEnCompte, busEvenements);
+        await utilisateurDeParcours.prendEnCompte(mesure, 5, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
         busEvenements.naPasRecuDEvenement(BadgeCyberdépartDébloqué);
       });

--- a/back/tests/metier/utilisateur.spec.ts
+++ b/back/tests/metier/utilisateur.spec.ts
@@ -171,7 +171,7 @@ describe("L'utilisateur", () => {
 
     it('publie un événement de completion quand toutes les mesures du module sont prises en compte', async () => {
       moduleCyberdépart.mesures = [mesureDeTest().construis()];
-      await utilisateurDeParcours.prendEnCompte(mesure, 1, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
+      await utilisateurDeParcours.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
       busEvenements.aRecuUnEvenement(ModuleTermine);
       const evenement = busEvenements.recupereEvenement(ModuleTermine);
@@ -184,7 +184,7 @@ describe("L'utilisateur", () => {
     it("ne publie pas d'événement de completion si toutes les mesures du module ne sont pas prises en compte", async () => {
       moduleCyberdépart.mesures = [mesureDeTest().construis(), mesureDeTest().construis()];
 
-      await utilisateurDeParcours.prendEnCompte(mesure, 2, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
+      await utilisateurDeParcours.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
       busEvenements.naPasRecuDEvenement(ModuleTermine);
     });
@@ -192,12 +192,11 @@ describe("L'utilisateur", () => {
     it("ignore la prise en compte d'une mesure déjà prise en compte", async () => {
       await utilisateurDeParcours.prendEnCompte(
         mesure,
-        2,
         entrepotPriseEnCompte,
         fabriqueBusPourLesTests(),
         moduleCyberdépart
       );
-      await utilisateurDeParcours.prendEnCompte(mesure, 2, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
+      await utilisateurDeParcours.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
       assert.equal(utilisateurDeParcours.mesuresPrisesEnCompte.length, 1);
       busEvenements.naPasRecuDEvenement(ModuleTermine);
@@ -218,7 +217,7 @@ describe("L'utilisateur", () => {
           mesureDeTest().construis(),
           mesureDeTest().construis(),
         ];
-        await utilisateurDeParcours.prendEnCompte(mesure, 5, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
+        await utilisateurDeParcours.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
         busEvenements.aRecuUnEvenement(BadgeCyberdépartDébloqué);
       });
@@ -231,7 +230,7 @@ describe("L'utilisateur", () => {
           mesureDeTest().avecLId('mes4').construis(),
         ];
 
-        await utilisateurDeParcours.prendEnCompte(mesure, 5, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
+        await utilisateurDeParcours.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
         busEvenements.naPasRecuDEvenement(BadgeCyberdépartDébloqué);
       });
@@ -242,7 +241,7 @@ describe("L'utilisateur", () => {
           mesureDeTest().avecLId('mes2').construis(),
         ];
 
-        await utilisateurDeParcours.prendEnCompte(mesure, 5, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
+        await utilisateurDeParcours.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
 
         busEvenements.naPasRecuDEvenement(BadgeCyberdépartDébloqué);
       });

--- a/back/tests/persistance/EntrepôtModuleMémoire.ts
+++ b/back/tests/persistance/EntrepôtModuleMémoire.ts
@@ -1,0 +1,9 @@
+import { EntrepôtModule } from '../../src/metier/EntrepotModule';
+import { Module } from '../../src/metier/module';
+import { EntrepotMemoire } from './entrepotMemoire';
+
+export class EntrepôtModuleMémoire extends EntrepotMemoire<Module> implements EntrepôtModule {
+  async parId(id: number): Promise<Module | undefined> {
+    return this.entites.find((module) => module.id === id);
+  }
+}

--- a/back/tests/persistance/EntrepôtModuleMémoire.ts
+++ b/back/tests/persistance/EntrepôtModuleMémoire.ts
@@ -4,6 +4,9 @@ import { EntrepotMemoire } from './entrepotMemoire';
 
 export class EntrepôtModuleMémoire extends EntrepotMemoire<Module> implements EntrepôtModule {
   async parId(id: number): Promise<Module | undefined> {
+    if (Number.isNaN(id)) {
+      throw new Error('pas un nombre');
+    }
     return this.entites.find((module) => module.id === id);
   }
 }

--- a/back/tests/persistance/entrepotMesureMemoire.ts
+++ b/back/tests/persistance/entrepotMesureMemoire.ts
@@ -1,9 +1,14 @@
 import { EntrepotMesure } from '../../src/metier/entrepotMesure';
 import { Mesure } from '../../src/metier/mesure';
+import { Module } from '../../src/metier/module';
 import { EntrepotMemoire } from './entrepotMemoire';
 
 export class EntrepotMesureMemoire extends EntrepotMemoire<Mesure> implements EntrepotMesure {
   async parId(id: string): Promise<Mesure | undefined> {
     return this.entites.find((mesure) => mesure.id === id);
+  }
+
+  async duModule(module: Module): Promise<Mesure[]> {
+    return this.entites.filter((mesure) => mesure.module === module);
   }
 }

--- a/back/tests/persistance/entrepotMesureMemoire.ts
+++ b/back/tests/persistance/entrepotMesureMemoire.ts
@@ -9,6 +9,6 @@ export class EntrepotMesureMemoire extends EntrepotMemoire<Mesure> implements En
   }
 
   async duModule(module: Module): Promise<Mesure[]> {
-    return this.entites.filter((mesure) => mesure.module === module);
+    return this.entites.filter((mesure) => mesure.module!.id === module.id);
   }
 }

--- a/front/lib-svelte/src/parcours-securisation/ModuleCyberdepart.svelte
+++ b/front/lib-svelte/src/parcours-securisation/ModuleCyberdepart.svelte
@@ -12,11 +12,12 @@
 
   let mesures: Mesure[] = $state([]);
   const totalMesures = $derived(mesures.length);
-  const cibleBadge = $derived(Math.floor(mesures.length * 0.8));
+  let cibleBadge = $state(0);
 
   onMount(async () => {
-    const reponse = await axios.get<{ mesures: Mesure[] }>(`/api/modules/1`);
+    const reponse = await axios.get<{ cibleBadge: number; mesures: Mesure[] }>(`/api/modules/1`);
     mesures = reponse.data.mesures;
+    cibleBadge = reponse.data.cibleBadge;
     if (sessionStorage.getItem('mesure-prise-en-compte') === 'true') {
       toasterStore.succes('Mesure déclarée prise en compte', 'Mesure déclarée prise en compte');
       sessionStorage.removeItem('mesure-prise-en-compte');

--- a/front/lib-svelte/src/parcours-securisation/ModuleCyberdepart.svelte
+++ b/front/lib-svelte/src/parcours-securisation/ModuleCyberdepart.svelte
@@ -15,8 +15,8 @@
   const cibleBadge = $derived(Math.floor(mesures.length * 0.8));
 
   onMount(async () => {
-    const reponse = await axios.get<Mesure[]>(`/api/modules/1/mesures`);
-    mesures = reponse.data;
+    const reponse = await axios.get<{ mesures: Mesure[] }>(`/api/modules/1/mesures`);
+    mesures = reponse.data.mesures;
     if (sessionStorage.getItem('mesure-prise-en-compte') === 'true') {
       toasterStore.succes('Mesure déclarée prise en compte', 'Mesure déclarée prise en compte');
       sessionStorage.removeItem('mesure-prise-en-compte');

--- a/front/lib-svelte/src/parcours-securisation/ModuleCyberdepart.svelte
+++ b/front/lib-svelte/src/parcours-securisation/ModuleCyberdepart.svelte
@@ -15,7 +15,7 @@
   const cibleBadge = $derived(Math.floor(mesures.length * 0.8));
 
   onMount(async () => {
-    const reponse = await axios.get<Mesure[]>(`/api/modules/cyberdepart/mesures`);
+    const reponse = await axios.get<Mesure[]>(`/api/modules/1/mesures`);
     mesures = reponse.data;
     if (sessionStorage.getItem('mesure-prise-en-compte') === 'true') {
       toasterStore.succes('Mesure déclarée prise en compte', 'Mesure déclarée prise en compte');

--- a/front/lib-svelte/src/parcours-securisation/ModuleCyberdepart.svelte
+++ b/front/lib-svelte/src/parcours-securisation/ModuleCyberdepart.svelte
@@ -15,7 +15,7 @@
   const cibleBadge = $derived(Math.floor(mesures.length * 0.8));
 
   onMount(async () => {
-    const reponse = await axios.get<{ mesures: Mesure[] }>(`/api/modules/1/mesures`);
+    const reponse = await axios.get<{ mesures: Mesure[] }>(`/api/modules/1`);
     mesures = reponse.data.mesures;
     if (sessionStorage.getItem('mesure-prise-en-compte') === 'true') {
       toasterStore.succes('Mesure déclarée prise en compte', 'Mesure déclarée prise en compte');


### PR DESCRIPTION
… afin de ne pas mélanger les mesures des différents modules, que ce soit dans les mesures retournées et affichées ou dans les événements remontés.
On en profite pour faire quelques soins métier et faire émerger les propriétés métier. 