### PR TITLE
[SEO] Corrige l'URL canonique pour inclure le `site.url`

### DIFF
--- a/front/_includes/head.html
+++ b/front/_includes/head.html
@@ -20,7 +20,7 @@
       {% assign urlSansSlashFinal = urlSansSlashFinal | slice: 0, new_length %}
     {% endif %}
   {% endif %}
-  <link rel="canonical" href="{{ urlSansSlashFinal }}" />
+  <link rel="canonical" href="{{ site.url }}{{ urlSansSlashFinal }}" />
   <meta name="description" content="{{ site.data.meta-description[page.url] | escape }}">
   {% if page.noindex %}<meta name="robots" content="noindex, nofollow">{% endif %}
 


### PR DESCRIPTION
## Décrire les changements

### Explication du problème 
La balise `<link rel="canonical" />` contenait uniquement la variable `{{ urlSansSlashFinal }}` dans son attribut `href`.

Hors la variable `{{ urlSansSlashFinal }}` ne semble contenir que le slug de la page courante mais sans le début du nom de domaine à savoir `https://messervices.cyber.gouv.fr/`. 

Cela conduisait à avoir un résultat de la forme suivante, par exemple :  `<link rel="canonical" href="/test-maturite">`.

### Correctif
Cette PR ajoute la variable `{{ site.url }}` à la variable `{{ urlSansSlashFinal }}` dans la balise `<link rel="canonical" />` afin d'obtenir l'url complète de la page et obtenir ainsi le rendu suivant : `<link rel="canonical" href="https://messervices.cyber.gouv.fr/test-maturite">`.
