### PR TITLE
[MATOMO] Ajoute la campagne Matomo à l'origine des demandes daide

### DIFF
--- a/front/lib-svelte/src/demande-aide-mon-aide-cyber/DemandeDiagnosticSimplifiee.svelte
+++ b/front/lib-svelte/src/demande-aide-mon-aide-cyber/DemandeDiagnosticSimplifiee.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import FoireAuxQuestions from './FoireAuxQuestions.svelte';
   import FormulaireDemandeSimplifiee from './FormulaireDemandeSimplifiee.svelte';
 
@@ -10,6 +11,14 @@
   export let urlBase: string = '';
   export let cacheLesLiensDeRetour = false;
   export let siretAidant: string | undefined = undefined;
+
+  let campagne: string;
+  onMount(() => {
+    const parametres = new URLSearchParams(window.location.search);
+    campagne = parametres.get('mtm_campaign') ?? '';
+  });
+
+  $: origineComplète = campagne ? `${origine};${campagne}` : origine;
 </script>
 
 <div class="demande-diagnostic" class:autonome={mode === 'autonome'}>
@@ -28,7 +37,7 @@
   </div>
 
   <div class="formulaire">
-    <FormulaireDemandeSimplifiee {mode} {origine} {urlBase} {cacheLesLiensDeRetour} {siretAidant} />
+    <FormulaireDemandeSimplifiee {mode} origine={origineComplète} {urlBase} {cacheLesLiensDeRetour} {siretAidant} />
   </div>
   <details>
     <summary>


### PR DESCRIPTION
# Description

Pour toute utilisation de la campagne vai le composant `DemandeDiagnosticSimplifiee.svelte`, maintenant, le query param `mtm_campaign` est ajouté aux origines transmises par celui-ci.

## Exemple

pour une URL `<domain>/nis2?mtm_campaign=toto`
le formulaire enverra dans le body la clef JSON `origine: "nis2;toto"`.

Les campagnes sont concaténées et séparées par un `;`.