### PR TITLE
[PARCOURS SECURISATION] Ajoute les totaux des événements de déblocage

### DIFF
--- a/back/src/bus/consigneBadgeCyberdepartDebloqueDansJournal.ts
+++ b/back/src/bus/consigneBadgeCyberdepartDebloqueDansJournal.ts
@@ -13,6 +13,8 @@ export const consigneBadgeCyberdépartDébloquéDansJournal = ({
     await adaptateurJournal.consigneEvenement({
       donnees: {
         idUtilisateur: evenement.emailHache,
+        nombreMesuresActuel: evenement.nombreMesuresActuel,
+        nombreMesuresTotal: evenement.nombreMesuresTotal,
       },
       type: 'BADGE_CYBERDEPART_DEBLOQUE',
       date: adaptateurHorloge.maintenant(),

--- a/back/src/bus/evenements/badgeCyberdepartDebloque.ts
+++ b/back/src/bus/evenements/badgeCyberdepartDebloque.ts
@@ -1,3 +1,7 @@
 export class BadgeCyberdépartDébloqué {
-  constructor(readonly emailHache: string) {}
+  constructor(
+    readonly emailHache: string,
+    readonly nombreMesuresActuel: number,
+    readonly nombreMesuresTotal: number
+  ) {}
 }

--- a/back/src/infra/donneesEvenement.ts
+++ b/back/src/infra/donneesEvenement.ts
@@ -97,4 +97,7 @@ type DonneesMesurePriseEnCompte = Evenement<
 
 type DonneesModuleTerminé = Evenement<'MODULE_TERMINE', Omit<ModuleTermine, 'emailHache'> & { idUtilisateur: string }>;
 
-type DonnéesBadgeCyberdépartDébloqué = Evenement<'BADGE_CYBERDEPART_DEBLOQUE', { idUtilisateur: string }>;
+type DonnéesBadgeCyberdépartDébloqué = Evenement<
+  'BADGE_CYBERDEPART_DEBLOQUE',
+  { idUtilisateur: string; nombreMesuresActuel: number; nombreMesuresTotal: number }
+>;

--- a/back/src/metier/utilisateur.ts
+++ b/back/src/metier/utilisateur.ts
@@ -159,7 +159,9 @@ export class Utilisateur {
     }
     const cibleBadgeCyberdépart = module.cibleDéblocageBadgeCyberdépart();
     if (this.mesuresPrisesEnCompte.length === cibleBadgeCyberdépart) {
-      await busEvenements.publie(new BadgeCyberdépartDébloqué(this.emailHache()));
+      await busEvenements.publie(
+        new BadgeCyberdépartDébloqué(this.emailHache(), this.mesuresPrisesEnCompte.length, module.nombreDeMesures())
+      );
       nouvelEtatModule.badgeCyberdépartDebloqué = true;
     }
     return nouvelEtatModule;

--- a/back/tests/bus/consigneBadgeCyberdepartDebloqueDansJournal.spec.ts
+++ b/back/tests/bus/consigneBadgeCyberdepartDebloqueDansJournal.spec.ts
@@ -20,12 +20,14 @@ describe("L'abonnement qui consigne le déblocage du badge cyberdépart par un u
     await consigneBadgeCyberdépartDébloquéDansJournal({
       adaptateurJournal,
       adaptateurHorloge,
-    })(new BadgeCyberdépartDébloqué('u1@example.com-hache'));
+    })(new BadgeCyberdépartDébloqué('u1@example.com-hache', 8, 10));
 
     assert.deepEqual(evenementRecu, {
       type: 'BADGE_CYBERDEPART_DEBLOQUE',
       donnees: {
         idUtilisateur: 'u1@example.com-hache',
+        nombreMesuresActuel: 8,
+        nombreMesuresTotal: 10,
       },
       date: new Date('2025-03-10'),
     });

--- a/back/tests/metier/utilisateur.spec.ts
+++ b/back/tests/metier/utilisateur.spec.ts
@@ -281,6 +281,26 @@ describe("L'utilisateur", () => {
 
         busEvenements.naPasRecuDEvenement(BadgeCyberdépartDébloqué);
       });
+
+      it('publie les totaux lors du déblocage du badge', async () => {
+        utilisateurDeParcours.mesuresPrisesEnCompte = [
+          mesureDeTest().avecLId('mes1').construis(),
+          mesureDeTest().avecLId('mes2').construis(),
+          mesureDeTest().avecLId('mes3').construis(),
+        ];
+        moduleCyberdépart.mesures = [
+          mesureDeTest().construis(),
+          mesureDeTest().construis(),
+          mesureDeTest().construis(),
+          mesureDeTest().construis(),
+          mesureDeTest().construis(),
+        ];
+        await utilisateurDeParcours.prendEnCompte(mesure, entrepotPriseEnCompte, busEvenements, moduleCyberdépart);
+
+        const evenement = busEvenements.recupereEvenement(BadgeCyberdépartDébloqué);
+        assert.equal(4, evenement!.nombreMesuresActuel);
+        assert.equal(5, evenement!.nombreMesuresTotal);
+      });
     });
   });
 });


### PR DESCRIPTION
- total de mesures prises en compte actuel
- total de mesures dans le module. 

L’objectif est de conserver ces totaux pour en conserver une trace lorsque la cible de déblocage changera.