### PR TITLE
Dsfrise les tuiles

### DIFF
--- a/front/lib-svelte/src/statistiques/Tuile.svelte
+++ b/front/lib-svelte/src/statistiques/Tuile.svelte
@@ -1,41 +1,23 @@
 <script lang="ts">
-  export let image: string;
-  export let mesure: number;
-  export let description: string;
+  import Tuile from '../ui/Tuile.svelte';
+
+  type Props = {
+    image: string;
+    mesure: number;
+    description: string;
+  };
+
+  const { image, mesure, description: titre }: Props = $props();
 </script>
 
-<div class="tuile">
-  <img src={`/assets/images/${image}.svg`} width="96" height="96" alt={description} />
-  <span class="mesure">{mesure}</span>
-  <span class="description">{description}</span>
-</div>
+<Tuile {titre}>
+  <img slot="pictogram" src={`/assets/images/${image}.svg`} width="96" height="96" alt={titre} />
+  <span slot="description" class="mesure fr-h2">{mesure}</span>
+</Tuile>
 
 <style lang="scss">
-  .tuile {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 24px 32px 32px;
-
-    border: 1px var(--border-default-grey) solid;
-    border-radius: 8px;
-
-    img {
-      margin-bottom: 16px;
-    }
-
-    .mesure {
-      font-size: 1.75rem;
-      line-height: 2.25rem;
-      font-weight: bold;
-      color: #161616;
-      margin-bottom: 8px;
-    }
-    .description {
-      font-size: 1.125rem;
-      line-height: 1.75rem;
-      color: #3a3a3a;
-      text-align: center;
-    }
+  .mesure {
+    color: #161616;
+    margin-bottom: 8px;
   }
 </style>

--- a/front/lib-svelte/src/ui/Tuile.svelte
+++ b/front/lib-svelte/src/ui/Tuile.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  type Props = {
+    titre: string;
+    pictogram?: string;
+  };
+  const { titre, pictogram }: Props = $props();
+</script>
+
+<dsfr-tile title={titre} hasDescription={$$slots.description} {pictogram} actionMarkup="false">
+  <slot name="pictogram" slot="pictogram"></slot>
+  <slot name="description" slot="description"></slot>
+</dsfr-tile>


### PR DESCRIPTION
Je pense que le texte "gris" vient du fait que si c'est la tuile n'est pas cliquable, l'UI Kit rend toujours une balise `<a>` sans `href` et donc désactivé !

Après :
<img width="1232" height="541" alt="image" src="https://github.com/user-attachments/assets/5ceff3bf-1d37-4fc5-9619-24a8cb2f2336" />


Avant :
<img width="1257" height="540" alt="image" src="https://github.com/user-attachments/assets/03a91cb8-3a77-46b5-98d3-f7506d4b733d" />
