### PR TITLE
[CORRECTION]: Synchronise l'URL et les filtres via le composant fragmentDeNavigation

### DIFF
--- a/front/lib-svelte/src/catalogue/Catalogue.svelte
+++ b/front/lib-svelte/src/catalogue/Catalogue.svelte
@@ -97,7 +97,7 @@
     $rechercheParTypologie = fragmentDeNavigation.extraisTableau<Typologie>('types');
     $rechercheParSource = fragmentDeNavigation.extraisTableau<Source>('sources');
   };
-  appliqueLesFiltres(fragmentDeNavigation);
+  $effect(() => appliqueLesFiltres(fragmentDeNavigation));
   $effect(() => {
     fragmentDeNavigation.change('besoin', $rechercheParBesoin);
     fragmentDeNavigation.change('langues', $rechercheParLangue);

--- a/front/lib-svelte/src/contacts/Contacts.svelte
+++ b/front/lib-svelte/src/contacts/Contacts.svelte
@@ -33,7 +33,7 @@
     const parametreSecteur = fragmentDeNavigation.extraisValeur('secteur', '');
     secteurSelectionne = estCodeSecteurContact(parametreSecteur) ? parametreSecteur : '';
   };
-  appliqueLesFiltres();
+  $effect(() => appliqueLesFiltres());
   $effect(() => {
     fragmentDeNavigation.change('region', regionSelectionnee);
     fragmentDeNavigation.change('secteur', secteurSelectionne);

--- a/front/lib-svelte/src/navigation/fragmentDeNavigation.svelte.ts
+++ b/front/lib-svelte/src/navigation/fragmentDeNavigation.svelte.ts
@@ -68,7 +68,14 @@ export const creeLeFragmentDeNavigation = (hash?: string): FragmentDeNavigation 
       return section;
     },
     change: <T>(cle: string, valeur: T | T[]) => {
-      filtres[cle] = (Array.isArray(valeur) ? valeur : valeur ? [valeur] : []).map(String);
+      const nouvellesValeurs = (Array.isArray(valeur) ? valeur : valeur ? [valeur] : []).map(String);
+      const valeursActuelles = filtres[cle] ?? [];
+      const valeursIdentiques =
+        nouvellesValeurs.length === valeursActuelles.length &&
+        nouvellesValeurs.every((nouvelleValeur, index) => nouvelleValeur === valeursActuelles[index]);
+      if (!valeursIdentiques) {
+        filtres[cle] = nouvellesValeurs;
+      }
     },
     changeSection: (nouvelleSection: string | undefined, actualise: boolean) => {
       section = nouvelleSection;


### PR DESCRIPTION
Corrige la synchronisation des filtres du catalogue lors d’une modification manuelle du fragment d’URL. Les paramètres ajoutés, modifiés ou supprimés mettent désormais immédiatement l’interface à jour, sans boucle de réactivité.