### PR TITLE
[CORRECTION]: explicite la racine des configurations TypeScript

### DIFF
--- a/comparaison-grist/eslint.config.mjs
+++ b/comparaison-grist/eslint.config.mjs
@@ -24,5 +24,10 @@ export default tseslint.config(
         },
       ],
     },
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
   }
 );

--- a/mise-a-jour-financements/eslint.config.mjs
+++ b/mise-a-jour-financements/eslint.config.mjs
@@ -24,5 +24,10 @@ export default tseslint.config(
         },
       ],
     },
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
   }
 );


### PR DESCRIPTION
Corrige l’erreur ESLint liée à la détection de plusieurs racines TypeScript dans le monorepo.

## Changements

- définit explicitement `tsconfigRootDir` dans la configuration ESLint de `mise-a-jour-financements`
- définit explicitement `tsconfigRootDir` dans la configuration ESLint de `comparaison-grist`
- utilise `import.meta.dirname` afin que chaque module référence son propre `tsconfig.json`