### PR TITLE
[PARCOURS SÉCURISATION] Redirige vers la page accédée avant authentification

### DIFF
--- a/back/src/api/middleware.ts
+++ b/back/src/api/middleware.ts
@@ -71,8 +71,11 @@ export const fabriqueMiddleware = ({
   };
 
   const verifieJWTNavigation = async (requete: Request, reponse: Response, suite: NextFunction) => {
+    const redirigeVersConnexion = () =>
+      reponse.redirect(`/connexion?urlRedirection=${encodeURIComponent(requete.originalUrl)}`);
+
     if (!requete.session?.token) {
-      reponse.redirect('/connexion');
+      redirigeVersConnexion();
       return;
     }
 
@@ -80,7 +83,7 @@ export const fabriqueMiddleware = ({
       adaptateurJWT.decode(requete.session.token);
       suite();
     } catch {
-      reponse.redirect('/connexion');
+      redirigeVersConnexion();
     }
   };
 

--- a/back/src/api/msc.ts
+++ b/back/src/api/msc.ts
@@ -57,6 +57,7 @@ import { ressourceStatistiques } from './ressourceStatistiques.js';
 import { ressourceStatistiquesDiagnostic } from './ressourceStatistiquesDiagnostic.js';
 import { ressourceUtilisateurs } from './ressourceUtilisateurs.js';
 import { ressourceVisa } from './ressourceVisa.js';
+import { routesPagesConnecteesStatiques } from './routesPagesConnectees.js';
 import { ressourceDernierResultatDeTest } from './testMaturite/ressourceDernierResultatDeTest.js';
 import { ressourceRepartitionDesResultatsDeTest } from './testMaturite/ressourceRepartitionDesResultatsDeTest.js';
 import { ressourceResultatDeTest } from './testMaturite/ressourceResultatDeTest.js';
@@ -206,7 +207,7 @@ const creeServeur = (configurationServeur: ConfigurationServeur) => {
 
   app.use('/guides/:slug', ressourcePagesJekyll(configurationServeur, 'guides'));
 
-  ['ma-maturite', 'favoris', 'services-anssi', 'gestion-guides'].forEach((page) =>
+  routesPagesConnecteesStatiques.forEach((page) =>
     app.use(`/${page}`, ressourcePagesJekyllConnectees(configurationServeur, page))
   );
 

--- a/back/src/api/ressourcePageConnexion.ts
+++ b/back/src/api/ressourcePageConnexion.ts
@@ -3,6 +3,7 @@ import { ConfigurationServeur } from './configurationServeur.js';
 import { detruisSession } from './session.js';
 import { corpsVide, valideCorpsRequete } from './zod.js';
 import { filetRouteAsynchrone } from './middleware.js';
+import { estUrlRedirectionApresConnexionAutorisee } from './routesPagesConnectees.js';
 
 const ressourcePageConnexion = ({ fournisseurChemin }: ConfigurationServeur): Router => {
   const routeur = Router();
@@ -11,6 +12,15 @@ const ressourcePageConnexion = ({ fournisseurChemin }: ConfigurationServeur): Ro
     '/',
     valideCorpsRequete(corpsVide),
     filetRouteAsynchrone(async (requete: Request, reponse: Response) => {
+      const urlRedirection = requete.query.urlRedirection;
+      if (
+        urlRedirection !== undefined &&
+        (typeof urlRedirection !== 'string' || !estUrlRedirectionApresConnexionAutorisee(urlRedirection))
+      ) {
+        reponse.redirect('/connexion');
+        return;
+      }
+
       detruisSession(requete, reponse);
       await reponse
         .contentType('text/html')

--- a/back/src/api/routesPagesConnectees.ts
+++ b/back/src/api/routesPagesConnectees.ts
@@ -1,0 +1,24 @@
+const origineDeReferencePourValidation = 'https://origine-interne.invalid';
+
+export const routesPagesConnecteesStatiques = ['ma-maturite', 'favoris', 'services-anssi', 'gestion-guides'] as const;
+
+const cheminsPagesConnecteesStatiques = new Set([
+  ...routesPagesConnecteesStatiques.map((page) => `/${page}`),
+  '/parcours-complet',
+]);
+const motifsPagesConnecteesAvecParametre = [/^\/modules\/[^/]+$/, /^\/mesures\/[^/]+$/];
+
+export const estUrlRedirectionApresConnexionAutorisee = (valeur: string): boolean => {
+  try {
+    const url = new URL(valeur, origineDeReferencePourValidation);
+    const cheminSansSlashFinal = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname;
+
+    return (
+      url.origin === origineDeReferencePourValidation &&
+      (cheminsPagesConnecteesStatiques.has(cheminSansSlashFinal) ||
+        motifsPagesConnecteesAvecParametre.some((motif) => motif.test(cheminSansSlashFinal)))
+    );
+  } catch {
+    return false;
+  }
+};

--- a/back/src/api/routesPagesConnectees.ts
+++ b/back/src/api/routesPagesConnectees.ts
@@ -6,18 +6,20 @@ const cheminsPagesConnecteesStatiques = new Set([
   ...routesPagesConnecteesStatiques.map((page) => `/${page}`),
   '/parcours-complet',
 ]);
-const motifsPagesConnecteesAvecParametre = [/^\/modules\/[^/]+$/, /^\/mesures\/[^/]+$/];
+const cheminsPagesConnectéesAvecParamètres = ['/modules/', '/mesures/'];
 
 export const estUrlRedirectionApresConnexionAutorisee = (valeur: string): boolean => {
   try {
     const url = new URL(valeur, origineDeReferencePourValidation);
     const cheminSansSlashFinal = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname;
 
-    return (
-      url.origin === origineDeReferencePourValidation &&
-      (cheminsPagesConnecteesStatiques.has(cheminSansSlashFinal) ||
-        motifsPagesConnecteesAvecParametre.some((motif) => motif.test(cheminSansSlashFinal)))
+    const aLaMêmeOrigine = url.origin === origineDeReferencePourValidation;
+    const aUnCheminStatiqueValide = cheminsPagesConnecteesStatiques.has(cheminSansSlashFinal);
+    const aUnCheminAvecParamètresValide = cheminsPagesConnectéesAvecParamètres.some((motif) =>
+      cheminSansSlashFinal.startsWith(motif)
     );
+
+    return aLaMêmeOrigine && (aUnCheminStatiqueValide || aUnCheminAvecParamètresValide);
   } catch {
     return false;
   }

--- a/back/tests/api/middleware.spec.ts
+++ b/back/tests/api/middleware.spec.ts
@@ -129,6 +129,7 @@ describe('Le middleware', () => {
 
   describe('sur demande de validation du token JWT en cas de navigation', () => {
     it("redirige vers la page de connexion si le token n'est pas présent", async () => {
+      requete.originalUrl = '/favoris?tri=recent';
       let urlRecu;
       // @ts-expect-error (on sait que redirect va être appelé avec une URL et pas un code HTTP dans ce cas)
       reponse.redirect = (url: string) => {
@@ -138,7 +139,7 @@ describe('Le middleware', () => {
 
       await middleware.verifieJWTNavigation(requete, reponse, () => {});
 
-      assert.equal(urlRecu, '/connexion');
+      assert.equal(urlRecu, '/connexion?urlRedirection=%2Ffavoris%3Ftri%3Drecent');
     });
 
     it('redirige vers la page de connexion si le token ne peut pas être décodé', async () => {
@@ -148,6 +149,7 @@ describe('Le middleware', () => {
       requete.session = {
         token: 'unToken',
       };
+      requete.originalUrl = '/ma-maturite';
 
       let urlRecu;
       // @ts-expect-error (on sait que redirect va être appelé avec une URL et pas un code HTTP dans ce cas)
@@ -158,7 +160,7 @@ describe('Le middleware', () => {
 
       await middleware.verifieJWTNavigation(requete, reponse, () => {});
 
-      assert.equal(urlRecu, '/connexion');
+      assert.equal(urlRecu, '/connexion?urlRedirection=%2Fma-maturite');
     });
   });
 

--- a/back/tests/api/ressourcePageConnexion.spec.ts
+++ b/back/tests/api/ressourcePageConnexion.spec.ts
@@ -46,6 +46,19 @@ describe('La ressource de la page connexion', () => {
       assert.equal(nomPageDemande!, 'connexion');
     });
 
+    it('accepte une URL de redirection vers une page connectée', async () => {
+      const reponse = await request(serveur).get('/connexion').query({ urlRedirection: '/favoris?tri=recent' });
+
+      assert.equal(reponse.status, 200);
+    });
+
+    it('refuse une URL de redirection non autorisée', async () => {
+      const reponse = await request(serveur).get('/connexion').query({ urlRedirection: 'https://example.com/favoris' });
+
+      assert.equal(reponse.status, 302);
+      assert.equal(reponse.headers.location, '/connexion');
+    });
+
     it("supprime la session de l'utilisateur", async () => {
       const cookieSession = encodeSession({ token: 'token-session' });
 

--- a/back/tests/api/routesPagesConnectees.spec.ts
+++ b/back/tests/api/routesPagesConnectees.spec.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { estUrlRedirectionApresConnexionAutorisee } from '../../src/api/routesPagesConnectees.js';
+
+describe("L'URL de redirection après connexion", () => {
+  it('autorise les pages connectées fixes', () => {
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('/ma-maturite'), true);
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('/parcours-complet'), true);
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('/favoris'), true);
+  });
+
+  it('autorise les pages connectées fixes avec paramètres et fragment', () => {
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('/favoris?tri=recent#liste'), true);
+  });
+
+  it('autorise les pages connectées dynamiques', () => {
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('/modules/42'), true);
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('/mesures/une-mesure/'), true);
+  });
+
+  it('interdit une page publique', () => {
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('/catalogue'), false);
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('/?'), false);
+  });
+
+  it('interdit les URL externes', () => {
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('https://example.com/favoris'), false);
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('//example.com/favoris'), false);
+    assert.equal(estUrlRedirectionApresConnexionAutorisee('javascript:alert(1)'), false);
+  });
+});

--- a/front/connexion.html
+++ b/front/connexion.html
@@ -5,6 +5,8 @@ titreHtml: 'Connexion | MesServicesCyber'
 styles: /assets/styles/connexion.css
 ---
 
+<script type="module" src="/scripts/connexion.js"></script>
+
 <dsfr-container class="connexion">
   <div class="contenu-section">
     <div class="contenu-principal">

--- a/front/lib-svelte/src/test-maturite/EncartDeRecommandationMaturiteForte.svelte
+++ b/front/lib-svelte/src/test-maturite/EncartDeRecommandationMaturiteForte.svelte
@@ -2,7 +2,7 @@
   import { clic } from '../directives/actions.svelte';
 
   const connexion = () => {
-    sessionStorage.setItem('pagePostConnexion', 'comparaison-maturite');
+    sessionStorage.setItem('pagePostConnexion', '/ma-maturite#comparaison');
   };
 </script>
 

--- a/front/scripts/apres-authentification.js
+++ b/front/scripts/apres-authentification.js
@@ -1,11 +1,18 @@
 document.addEventListener('DOMContentLoaded', () => {
   const pagePostConnexion = sessionStorage.getItem('pagePostConnexion');
-  switch (pagePostConnexion) {
-    case 'comparaison-maturite':
-      window.location = '/ma-maturite#comparaison';
-      break;
-    default:
-      window.location = '/catalogue';
-  }
   sessionStorage.removeItem('pagePostConnexion');
+
+  try {
+    if (pagePostConnexion) {
+      const urlPostConnexion = new URL(pagePostConnexion, window.location.origin);
+      if (urlPostConnexion.origin === window.location.origin) {
+        window.location = urlPostConnexion.href;
+        return;
+      }
+    }
+  } catch {
+    // La redirection par défaut est appliquée.
+  }
+
+  window.location = '/catalogue';
 });

--- a/front/scripts/connexion.js
+++ b/front/scripts/connexion.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  sessionStorage.removeItem('pagePostConnexion');
+
+  const urlRedirection = new URL(window.location.href).searchParams.get('urlRedirection');
+  if (!urlRedirection) return;
+
+  const urlPostConnexion = new URL(urlRedirection, window.location.origin);
+  if (urlPostConnexion.origin === window.location.origin) {
+    sessionStorage.setItem('pagePostConnexion', urlPostConnexion.href);
+  }
+});


### PR DESCRIPTION
## Description

Lorsqu’un utilisateur accède à une page protégée sans être authentifié, l’URL demandée est désormais transmise à la page de connexion, enregistrée dans le `sessionStorage` du navigateur, puis utilisée après l’authentification.

Cette modification :

- conserve le chemin, les paramètres de requête et le fragment de navigation ;
- limite la redirection aux URLs de même origine ;
- limite la redirection aux URLs protégées par une connexion ;
- toute tentative malicieuse de hack d'url de redirection redirige vers la page de connexion via un 302 ;
- conserve la redirection par défaut vers `/catalogue` ;
- ajoute les tests du middleware pour les utilisateurs non authentifiés ou dont le jeton est invalide.