### PR TITLE
[CORRECTION] Construis Svelte après la connexion à CC

### DIFF
--- a/.github/workflows/deploiement-node.yml
+++ b/.github/workflows/deploiement-node.yml
@@ -40,11 +40,6 @@ jobs:
         with:
           version: 10.24.0
 
-      - name: Construis la lib Svelte
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm --filter @anssi-portail/svelte build
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
@@ -65,6 +60,11 @@ jobs:
         run: |
           clever link "$ID_APP"
           clever env | grep -v "^#" | tr -d '"' >> "$GITHUB_ENV"
+
+      - name: Construis la lib Svelte
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @anssi-portail/svelte build
 
       - name: Construis avec Jekyll
         run: |

--- a/front/lib-svelte/vite.config.ts
+++ b/front/lib-svelte/vite.config.ts
@@ -27,7 +27,12 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, racineDuDepot, '');
   return {
     define: {
-      'import.meta.env.FEATURE_FLAG_NOUVELLE_DA': JSON.stringify(env.FEATURE_FLAG_NOUVELLE_DA),
+      // `loadEnv` ne lit que les fichiers `.env` présents sur le disque : sans fichier `.env`
+      // (cas de la CI, où `.env` est gitignoré), il ne reprend pas la variable déjà présente
+      // dans `process.env` (ex. injectée par `clever env`). D'où le fallback explicite.
+      'import.meta.env.FEATURE_FLAG_NOUVELLE_DA': JSON.stringify(
+        env.FEATURE_FLAG_NOUVELLE_DA ?? process.env.FEATURE_FLAG_NOUVELLE_DA ?? 'false'
+      ),
     },
     plugins: [
       svelte(),


### PR DESCRIPTION
... pour accéder aux variables d'envrionnement depuis `vite.config.ts` et lire `FEATURE_FLAG_NOUVELLE_DA`