### PR TITLE
[DEPENDANCES] Augmente le nombre de PR à 4

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "useBaseBranchConfig": "merge",
   "commitMessagePrefix": "[RENOVATE]",
   "prHourlyLimit": 10,
-  "prConcurrentLimit": 2,
+  "prConcurrentLimit": 4,
   "packageRules": [
     {
       "description": "lockFileMaintenance",


### PR DESCRIPTION
...proposées par Renovate simultanément, afin de pouvoir les traiter en lot sans attendre les vérifications.