### PR TITLE
[NOUVELLE DA] Fais évoluer les pages "parcours" approfondir et débuter

### DIFF
--- a/front/_includes/action-parcours-avec-items.html
+++ b/front/_includes/action-parcours-avec-items.html
@@ -1,4 +1,4 @@
-<dsfr-container id="{{include.id}}" class="action{% if include.fond == 'moutarde' %} fond-moutarde{% elsif include.fond == 'creme' %} fond-creme{% elsif include.fondAlternatif %} fond-alternatif{% endif %}">
+<dsfr-container id="{{include.id}}" class="action{% if include.fond == 'moutarde' %} fond-moutarde{% elsif include.fond == 'creme' %} fond-creme{% elsif include.fond == 'tournesol' %} fond-tournesol{% elsif include.fond == 'macaron' %} fond-macaron{% elsif include.fond == 'bourgeon' %} fond-bourgeon{% endif %}">
     <div class="contenu-section">
         <div class="description">
             <h2 class="fr-h1">{{include.titre}}</h2>

--- a/front/_includes/action-parcours-avec-items.html
+++ b/front/_includes/action-parcours-avec-items.html
@@ -3,7 +3,6 @@
         <div class="description">
             <h2 class="fr-h1">{{include.titre}}</h2>
             <p class="explication">{{include.explication}}</p>
-            <img class="illustration" src="/assets/images/illustration-{{include.id}}.svg" width="282" height="211" alt="Illustration {{include.titre}}"/>
         </div>
         <p class="fr-h3">Les services et ressources</p>
         {% for idItem in include.items %}

--- a/front/_includes/action-parcours-avec-items.html
+++ b/front/_includes/action-parcours-avec-items.html
@@ -1,4 +1,4 @@
-<dsfr-container id="{{include.id}}" class="action {% if include.fondAlternatif %} fond-alternatif{% endif %}">
+<dsfr-container id="{{include.id}}" class="action{% if include.fond == 'moutarde' %} fond-moutarde{% elsif include.fond == 'creme' %} fond-creme{% elsif include.fondAlternatif %} fond-alternatif{% endif %}">
     <div class="contenu-section">
         <div class="description">
             <h2 class="fr-h1">{{include.titre}}</h2>

--- a/front/_layouts/parcours.html
+++ b/front/_layouts/parcours.html
@@ -2,7 +2,6 @@
 layout: defaut
 styles:
   - /assets/styles/parcours.css
-  - /assets/styles/encart-cyberdepart.css
 script: /scripts/parcours.js
 ---
 

--- a/front/assets/styles/parcours.scss
+++ b/front/assets/styles/parcours.scss
@@ -79,8 +79,12 @@ dsfr-container.action {
     margin-bottom: 24px;
   }
 
-  &.fond-alternatif {
-    background: #fff7db;
+  &.fond-moutarde {
+    background: var(--yellow-moutarde-925-125);
+  }
+
+  &.fond-creme {
+    background: var(--brown-cafe-creme-975-75);
   }
 }
 

--- a/front/assets/styles/parcours.scss
+++ b/front/assets/styles/parcours.scss
@@ -86,6 +86,18 @@ dsfr-container.action {
   &.fond-creme {
     background: var(--brown-cafe-creme-975-75);
   }
+
+  &.fond-tournesol {
+    background: var(--yellow-tournesol-975-75);
+  }
+
+  &.fond-macaron {
+    background: var(--pink-macaron-925-125);
+  }
+
+  &.fond-bourgeon {
+    background: var(--green-bourgeon-975-75);
+  }
 }
 
 .chapeau.fond-sombre {

--- a/front/parcours-approfondir.html
+++ b/front/parcours-approfondir.html
@@ -101,5 +101,3 @@ titreHtml: 'Cybersécurité : approfondir ! | MesServicesCyber'
     fondAlternatif=fondAlternatif
   %}
 {% endfor %}
-
-{% include encart-nis2.html fond='sombre' %}

--- a/front/parcours-approfondir.html
+++ b/front/parcours-approfondir.html
@@ -85,11 +85,14 @@ titreHtml: 'Cybersécurité : approfondir ! | MesServicesCyber'
 </dsfr-container>
 
 {% for action in actions %}
-  {%assign indexModulo2 = forloop.index0 | modulo: 2 %}
-  {%if indexModulo2 == 1 %}
-    {%assign fondAlternatif=true%}
+  {%if forloop.index0 == 1 %}
+    {%assign fond="tournesol"%}
+  {%elsif forloop.index0 == 3 %}
+    {%assign fond="macaron"%}
+  {%elsif forloop.index0 == 5 %}
+    {%assign fond="bourgeon"%}
   {%else%}
-    {%assign fondAlternatif=false%}
+    {%assign fond="default"%}
   {%endif%}
   {% assign idAction=action.id %}
   {% include action-parcours-avec-items.html
@@ -98,6 +101,6 @@ titreHtml: 'Cybersécurité : approfondir ! | MesServicesCyber'
     explication=action.explication
     parcours=action.parcours
     items=action.items
-    fondAlternatif=fondAlternatif
+    fond=fond
   %}
 {% endfor %}

--- a/front/parcours-debuter.html
+++ b/front/parcours-debuter.html
@@ -85,11 +85,13 @@ titreHtml: 'Cybersécurité : se lancer ! | MesServicesCyber'
 </dsfr-container>
 
 {% for action in actions %}
-  {%assign indexModulo2 = forloop.index0 | modulo: 2 %}
-  {%if indexModulo2 == 1 %}
-    {%assign fondAlternatif=true%}
+  {%assign indexModulo3 = forloop.index0 | modulo: 3 %}
+  {%if indexModulo3 == 1 %}
+    {%assign fond="moutarde"%}
+  {%elsif indexModulo3 == 2 %}
+    {%assign fond="creme"%}
   {%else%}
-    {%assign fondAlternatif=false%}
+    {%assign fond="default"%}
   {%endif%}
   {% assign idAction=action.id %}
   {% include action-parcours-avec-items.html
@@ -98,6 +100,6 @@ titreHtml: 'Cybersécurité : se lancer ! | MesServicesCyber'
     explication=action.explication
     parcours=action.parcours
     items=action.items
-    fondAlternatif=fondAlternatif
+    fond=fond
   %}
 {% endfor %}

--- a/front/parcours-debuter.html
+++ b/front/parcours-debuter.html
@@ -101,5 +101,3 @@ titreHtml: 'Cybersécurité : se lancer ! | MesServicesCyber'
     fondAlternatif=fondAlternatif
   %}
 {% endfor %}
-
-{% include encart-cyberdepart.html fond='sombre' %}


### PR DESCRIPTION
## Description

Cette PR implémente les évolutions design de la nouvelle DA sur les pages "parcours débuter" et "parcours approfondir", à savori : 
- Suppression des encarts **CyberDépart** et **NIS2**.
- Suppression des illustrations de sections
- Applications des couleurs de fonds `moutarde`, `creme`, `tournesol`, `macaron` et `bourgeon` aux sections spécifiées.