### PR TITLE
[PARCOURS SECURISATION] Trace les clics depuis la vues des mesures

### DIFF
--- a/front/lib-svelte/src/global.d.ts
+++ b/front/lib-svelte/src/global.d.ts
@@ -1,7 +1,9 @@
 export {};
 
+type CustomData = { [key in `dimension${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10}`]?: string };
+
 declare global {
   interface Window {
-    _paq: { push: (tab: string[]) => void };
+    _paq: { push: (tab: Array<string | CustomData>) => void };
   }
 }

--- a/front/lib-svelte/src/parcours-securisation/parcours-complet/VueListeMesures.svelte
+++ b/front/lib-svelte/src/parcours-securisation/parcours-complet/VueListeMesures.svelte
@@ -38,6 +38,7 @@
           type={mesure.estPriseEnCompte ? 'tertiaire' : 'primaire'}
           href={`/mesures/${mesure.id}`}
           libelle={mesure.estPriseEnCompte ? 'Accédez aux détails' : "Passer à l'action"}
+          source="Vues des mesures"
         />
       </div>
     </li>

--- a/front/lib-svelte/src/ui/Lien.svelte
+++ b/front/lib-svelte/src/ui/Lien.svelte
@@ -57,12 +57,19 @@
         }[type]
       : 'primary'
   );
-  const traceClic = () => {
+  const traceClicVersMatomo = () => {
     const cible = href.startsWith('/') ? `${window.location.protocol}//${window.location.host}${href}` : href;
-    window._paq?.push(['trackLink', cible, telechargement ? 'download' : 'link']);
+    window._paq?.push([
+      'trackLink',
+      cible,
+      telechargement ? 'download' : 'link',
+      {
+        dimension2: window.location.href,
+      },
+    ]);
   };
   const auClic = (e: MouseEvent | KeyboardEvent) => {
-    traceClic();
+    traceClicVersMatomo();
     surClic?.(e);
   };
 </script>


### PR DESCRIPTION
...afin de mesurer l'impact de cette vue, et de son usage.

Les clics sont visualisables dans Matomo, menu Comportement > Action par page source :
<img width="917" height="812" alt="image" src="https://github.com/user-attachments/assets/6ef3a35a-fc13-4f99-a680-714b36d51077" />
