### PR TITLE
[SOIN] Prends en compte l'identifiant du test dans l'URL sur l'historique de maturité

### DIFF
--- a/front/lib-svelte/src/navigation/NavigationTertiaire.svelte
+++ b/front/lib-svelte/src/navigation/NavigationTertiaire.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { enPropriétéWebC } from '$plateforme/webComponent';
   import { onMount } from 'svelte';
+  import { extraisSegmentsDuFragment } from './fragmentDeNavigation.svelte';
 
   type Lien = { emoji?: string; label: string; fragment: string };
   type Props = {
@@ -11,10 +12,9 @@
   let { liens, lienActif = $bindable() }: Props = $props();
 
   const changeLeLienCourant = () => {
-    const hash = new URLSearchParams(window.location.hash?.substring(1));
-    const lienDansLUrl = Array.from(hash)[0];
-    if (lienDansLUrl) {
-      lienActif = liens.find((o) => o.fragment === `#${lienDansLUrl[0]}`)?.fragment ?? liens[0].fragment;
+    const [section] = extraisSegmentsDuFragment(window.location.hash);
+    if (section) {
+      lienActif = liens.find((lien) => lien.fragment === `#${section}`)?.fragment ?? liens[0].fragment;
     }
   };
 

--- a/front/lib-svelte/src/navigation/fragmentDeNavigation.svelte.ts
+++ b/front/lib-svelte/src/navigation/fragmentDeNavigation.svelte.ts
@@ -27,6 +27,9 @@ const fragmentSansComportement: FragmentDeNavigation = {
 
 const nettoie = (hash: string | undefined): string => hash?.replace(/^#/, '') ?? '';
 
+export const extraisSegmentsDuFragment = (hash: string | undefined): string[] =>
+  nettoie(hash).split('?')[0].split('/').filter(Boolean);
+
 export const creeLeFragmentDeNavigation = (hash?: string): FragmentDeNavigation => {
   if (hash === undefined && typeof window === 'undefined') {
     return fragmentSansComportement;

--- a/front/lib-svelte/src/niveaux-maturite/calculeIdNiveau.ts
+++ b/front/lib-svelte/src/niveaux-maturite/calculeIdNiveau.ts
@@ -1,0 +1,9 @@
+import type { IdNiveau } from './NiveauxMaturite.type';
+
+export const calculeIdNiveau = (moyenne: number): IdNiveau => {
+  if (moyenne < 1) return 'insuffisant';
+  if (moyenne < 2) return 'emergent';
+  if (moyenne < 3) return 'intermediaire';
+  if (moyenne < 4) return 'confirme';
+  return 'optimal';
+};

--- a/front/lib-svelte/src/test-maturite/CarteTestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/CarteTestMaturite.svelte
@@ -1,11 +1,11 @@
 <script context="module" lang="ts">
   import type { IdNiveau } from '../niveaux-maturite/NiveauxMaturite.type';
-  import type { ReponsesResultatTest } from './ResultatsTest.type';
-  export type ResultatTest = {
+  import type { RéponsesResultatTest } from './ResultatsTest.type';
+  export type RésultatTest = {
     dateRealisation: string;
     niveau: IdNiveau;
     id: string;
-    reponses: ReponsesResultatTest;
+    reponses: RéponsesResultatTest;
   };
 </script>
 
@@ -13,22 +13,22 @@
   import { niveauxMaturite } from '../niveaux-maturite/NiveauxMaturite.donnees';
   import { afficheNouvelleDA } from '$plateforme/environnement';
 
-  export let resultatTest: ResultatTest;
+  export let résultatTest: RésultatTest;
 
-  $: niveau = niveauxMaturite.find((niveau) => niveau.id === resultatTest.niveau);
+  $: niveau = niveauxMaturite.find((niveau) => niveau.id === résultatTest.niveau);
 
   $: description = niveau?.description;
   $: libelleNiveau = niveau?.label;
   $: dateFormatee = new Intl.DateTimeFormat('fr-FR', {
     dateStyle: 'long',
-  }).format(new Date(resultatTest.dateRealisation));
+  }).format(new Date(résultatTest.dateRealisation));
 </script>
 
-<a href="#historique/{resultatTest.id}" class="carte">
+<a href="#historique/{résultatTest.id}" class="carte">
   <div class="illustration-niveau" class:avec-nouvelle-da={afficheNouvelleDA}>
     <img
       class="plante"
-      src="/assets/images/test-maturite/niveaux/{resultatTest.niveau}{afficheNouvelleDA ? '-nouvelle-da' : ''}.svg"
+      src="/assets/images/test-maturite/niveaux/{résultatTest.niveau}{afficheNouvelleDA ? '-nouvelle-da' : ''}.svg"
       alt="Niveau de maturité"
     />
   </div>

--- a/front/lib-svelte/src/test-maturite/HistoriqueTests.svelte
+++ b/front/lib-svelte/src/test-maturite/HistoriqueTests.svelte
@@ -2,61 +2,61 @@
   import axios from 'axios';
   import { onMount } from 'svelte';
   import Lien from '../ui/Lien.svelte';
-  import CarteTestMaturite, { type ResultatTest } from './CarteTestMaturite.svelte';
+  import CarteTestMaturite, { type RésultatTest } from './CarteTestMaturite.svelte';
   import ResultatsMonOrganisation from './ResultatsMonOrganisation.svelte';
   import { questionnaireStore } from './stores/questionnaire.store';
 
-  export let idResultatTest: string | undefined;
+  export let idRésultatTest: string | undefined;
 
-  let resultatsTest: ResultatTest[] = [];
-  let resultatsTestParAnnee: ResultatsParAnnee = {};
+  let résultatsTest: RésultatTest[] = [];
+  let résultatsTestParAnnée: RésultatsParAnnée = {};
 
-  type ResultatsParAnnee = Record<number, ResultatTest[]>;
+  type RésultatsParAnnée = Record<number, RésultatTest[]>;
 
   onMount(async () => {
-    const reponse = await axios.get<ResultatTest[]>('/api/resultats-test');
-    resultatsTest = reponse.data;
-    resultatsTestParAnnee = resultatsTest
+    const réponse = await axios.get<RésultatTest[]>('/api/resultats-test');
+    résultatsTest = réponse.data;
+    résultatsTestParAnnée = résultatsTest
       .sort((a, b) => new Date(b.dateRealisation).getTime() - new Date(a.dateRealisation).getTime())
-      .reduce((accumulateur: ResultatsParAnnee, element: ResultatTest) => {
-        const annee = new Date(element.dateRealisation).getFullYear();
-        if (!(annee in accumulateur)) accumulateur[annee] = [];
-        accumulateur[annee].push(element);
+      .reduce((accumulateur: RésultatsParAnnée, élément: RésultatTest) => {
+        const année = new Date(élément.dateRealisation).getFullYear();
+        if (!(année in accumulateur)) accumulateur[année] = [];
+        accumulateur[année].push(élément);
         return accumulateur;
-      }, {} as ResultatsParAnnee);
+      }, {} as RésultatsParAnnée);
   });
 
-  $: annees = Object.keys(resultatsTestParAnnee)
+  $: années = Object.keys(résultatsTestParAnnée)
     .map((a) => Number(a))
     .sort((a, b) => b - a);
-
-  $: resultatTestSelectionne = idResultatTest
-    ? resultatsTest.find((resultat) => resultat.id === idResultatTest)
+  $: résultatTestSelectionné = idRésultatTest
+    ? résultatsTest.find((résultat) => résultat.id === idRésultatTest)
     : undefined;
 
   $: {
-    if (resultatTestSelectionne) questionnaireStore.chargeReponses(resultatTestSelectionne.reponses);
+    if (résultatTestSelectionné) questionnaireStore.chargeRéponses(résultatTestSelectionné.reponses);
   }
 </script>
 
-{#if resultatTestSelectionne}
+{#if résultatTestSelectionné}
   <dsfr-container class="section-retour-historique">
     <Lien href="/ma-maturite#historique" libelle="Retour" icone="arrow-go-back-line" />
   </dsfr-container>
   <ResultatsMonOrganisation
     animeTuiles={false}
-    dateRealisation={new Date(resultatTestSelectionne.dateRealisation)}
+    dateRealisation={new Date(résultatTestSelectionné.dateRealisation)}
     defilementAutomatique={false}
   />
 {:else}
   <dsfr-container>
     <h2>Historique de votre maturité cyber</h2>
-    {#each annees as annee (annee)}
+
+    {#each années as année (année)}
       <div class="annee">
-        <h3>{annee}</h3>
+        <h3>{année}</h3>
         <div class="cartes">
-          {#each resultatsTestParAnnee[Number(annee)] as resultatTest (resultatTest.id)}
-            <CarteTestMaturite {resultatTest} />
+          {#each résultatsTestParAnnée[Number(année)] as résultatTest (résultatTest.id)}
+            <CarteTestMaturite {résultatTest} />
           {/each}
         </div>
       </div>

--- a/front/lib-svelte/src/test-maturite/HistoriqueTests.svelte
+++ b/front/lib-svelte/src/test-maturite/HistoriqueTests.svelte
@@ -52,7 +52,7 @@
     <h2>Historique de votre maturité cyber</h2>
 
     {#each années as année (année)}
-      <div class="annee">
+      <div>
         <h3>{année}</h3>
         <div class="cartes">
           {#each résultatsTestParAnnée[Number(année)] as résultatTest (résultatTest.id)}

--- a/front/lib-svelte/src/test-maturite/HistoriqueTests.svelte
+++ b/front/lib-svelte/src/test-maturite/HistoriqueTests.svelte
@@ -4,7 +4,6 @@
   import Lien from '../ui/Lien.svelte';
   import CarteTestMaturite, { type RésultatTest } from './CarteTestMaturite.svelte';
   import ResultatsMonOrganisation from './ResultatsMonOrganisation.svelte';
-  import { questionnaireStore } from './stores/questionnaire.store';
 
   export let idRésultatTest: string | undefined;
 
@@ -32,10 +31,6 @@
   $: résultatTestSelectionné = idRésultatTest
     ? résultatsTest.find((résultat) => résultat.id === idRésultatTest)
     : undefined;
-
-  $: {
-    if (résultatTestSelectionné) questionnaireStore.chargeRéponses(résultatTestSelectionné.reponses);
-  }
 </script>
 
 {#if résultatTestSelectionné}
@@ -46,6 +41,7 @@
     animeTuiles={false}
     dateRealisation={new Date(résultatTestSelectionné.dateRealisation)}
     defilementAutomatique={false}
+    idNiveau={résultatTestSelectionné.niveau}
   />
 {:else}
   <dsfr-container>

--- a/front/lib-svelte/src/test-maturite/MaturiteUtilisateur.svelte
+++ b/front/lib-svelte/src/test-maturite/MaturiteUtilisateur.svelte
@@ -14,7 +14,7 @@
       const reponseHttp = await axios.get<DernierResultatTest>('/api/resultats-test/dernier');
       const reponses = reponseHttp.data.reponses;
       dateRealisationDernierTest = new Date(reponseHttp.data.dateRealisation);
-      questionnaireStore.chargeReponses(reponses);
+      questionnaireStore.chargeRéponses(reponses);
     } catch (e) {
       if (e instanceof AxiosError && e.status === 404) {
         window.location.href = '/test-maturite';

--- a/front/lib-svelte/src/test-maturite/MaturiteUtilisateur.svelte
+++ b/front/lib-svelte/src/test-maturite/MaturiteUtilisateur.svelte
@@ -3,18 +3,13 @@
   import { onMount } from 'svelte';
   import type { DernierResultatTest } from './ResultatsTest.type';
   import ResultatsTestMaturite from './ResultatsTestMaturite.svelte';
-  import { questionnaireStore } from './stores/questionnaire.store';
 
-  let dateRealisationDernierTest: Date | undefined;
-
-  questionnaireStore.initialise();
+  let dernierRésultatTest: DernierResultatTest | undefined;
 
   onMount(async () => {
     try {
       const reponseHttp = await axios.get<DernierResultatTest>('/api/resultats-test/dernier');
-      const reponses = reponseHttp.data.reponses;
-      dateRealisationDernierTest = new Date(reponseHttp.data.dateRealisation);
-      questionnaireStore.chargeRéponses(reponses);
+      dernierRésultatTest = reponseHttp.data;
     } catch (e) {
       if (e instanceof AxiosError && e.status === 404) {
         window.location.href = '/test-maturite';
@@ -25,4 +20,11 @@
   });
 </script>
 
-<ResultatsTestMaturite animeTuiles={false} {dateRealisationDernierTest} defilementAutomatique={false} />
+{#if dernierRésultatTest}
+  <ResultatsTestMaturite
+    animeTuiles={false}
+    dateRealisation={new Date(dernierRésultatTest.dateRealisation)}
+    idNiveau={dernierRésultatTest.idNiveau}
+    defilementAutomatique={false}
+  />
+{/if}

--- a/front/lib-svelte/src/test-maturite/ResultatsMonOrganisation.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsMonOrganisation.svelte
@@ -1,21 +1,15 @@
 <script lang="ts">
   import { niveauxMaturite } from '../niveaux-maturite/NiveauxMaturite.donnees';
+  import type { IdNiveau } from '../niveaux-maturite/NiveauxMaturite.type';
   import Lien from '../ui/Lien.svelte';
   import EncartDeRecommandationSelonMaturite from './EncartDeRecommandationSelonMaturite.svelte';
   import PartageTest from './PartageTest.svelte';
-  import { calculeIdNiveau } from './resultatTest';
-  import { questionnaireStore } from './stores/questionnaire.store';
   import TuilesMaturite from './TuilesMaturite.svelte';
 
   export let animeTuiles = true;
   export let dateRealisation: Date | undefined = undefined;
   export let defilementAutomatique = true;
-
-  $: moyenne =
-    $questionnaireStore.toutesLesReponses.reduce((acc, valeur) => acc + valeur, 0) /
-    $questionnaireStore.toutesLesReponses.length;
-
-  $: idNiveau = calculeIdNiveau(moyenne);
+  export let idNiveau: IdNiveau;
 
   const trouveNiveauMaturiteParId = (id: string) =>
     niveauxMaturite.find((niveau) => niveau.id === id) || niveauxMaturite[0];

--- a/front/lib-svelte/src/test-maturite/ResultatsMonOrganisation.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsMonOrganisation.svelte
@@ -1,23 +1,15 @@
 <script lang="ts">
   import { niveauxMaturite } from '../niveaux-maturite/NiveauxMaturite.donnees';
-  import type { IdNiveau } from '../niveaux-maturite/NiveauxMaturite.type';
   import Lien from '../ui/Lien.svelte';
   import EncartDeRecommandationSelonMaturite from './EncartDeRecommandationSelonMaturite.svelte';
   import PartageTest from './PartageTest.svelte';
+  import { calculeIdNiveau } from './resultatTest';
   import { questionnaireStore } from './stores/questionnaire.store';
   import TuilesMaturite from './TuilesMaturite.svelte';
 
   export let animeTuiles = true;
   export let dateRealisation: Date | undefined = undefined;
   export let defilementAutomatique = true;
-
-  const calculeIdNiveau = (moyenne: number): IdNiveau => {
-    if (moyenne < 1) return 'insuffisant';
-    if (moyenne < 2) return 'emergent';
-    if (moyenne < 3) return 'intermediaire';
-    if (moyenne < 4) return 'confirme';
-    return 'optimal';
-  };
 
   $: moyenne =
     $questionnaireStore.toutesLesReponses.reduce((acc, valeur) => acc + valeur, 0) /

--- a/front/lib-svelte/src/test-maturite/ResultatsSessionGroupe.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsSessionGroupe.svelte
@@ -9,7 +9,7 @@
   import LegendeAnneau from './LegendeAnneau.svelte';
   import LegendeRadarSessionGroupe from './LegendeRadarSessionGroupe.svelte';
   import RadarSessionGroupe from './RadarSessionGroupe.svelte';
-  import type { ReponsesResultatTest } from './ResultatsTest.type';
+  import type { RéponsesResultatTest } from './ResultatsTest.type';
   import { type Serie, type SerieRadar } from './Serie';
   import TuilesMaturiteSessionGroupe from './TuilesMaturiteSessionGroupe.svelte';
   import Heros from '../ui/Heros.svelte';
@@ -19,7 +19,7 @@
 
   type ResumeNiveau = {
     total: number;
-    moyennes: ReponsesResultatTest;
+    moyennes: RéponsesResultatTest;
   };
   type ResultatsSessionGroupe = {
     nombreParticipants: number;

--- a/front/lib-svelte/src/test-maturite/ResultatsTest.type.ts
+++ b/front/lib-svelte/src/test-maturite/ResultatsTest.type.ts
@@ -1,7 +1,7 @@
 import type { IdNiveau } from '../niveaux-maturite/NiveauxMaturite.type';
 import type { IdRubrique } from './TestMaturite.type';
 
-export type ReponsesResultatTest = Record<IdRubrique, number>;
+export type RéponsesResultatTest = Record<IdRubrique, number>;
 
 export type CodeLibelle = {
   code: string;
@@ -15,7 +15,7 @@ export type InfosOrganisation = {
 };
 
 export type DernierResultatTest = {
-  reponses: ReponsesResultatTest;
+  reponses: RéponsesResultatTest;
   dateRealisation: string;
   idNiveau: IdNiveau;
   organisation: InfosOrganisation;

--- a/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
@@ -21,13 +21,13 @@
   export let defilementAutomatique = true;
 
   let lienActif: CleOnglet | undefined;
-  let idResultatTest: string | undefined;
+  let idRésultatTest: string | undefined;
   let propriétésFilAriane: PropriétésFilAriane;
 
   const changeOngletActif = () => {
     const ongletRiche = window.location.hash.slice(1).split('/');
     const onglet = ongletRiche[0];
-    idResultatTest = ongletRiche?.[1];
+    idRésultatTest = ongletRiche?.[1];
     lienActif = clesOnglet.includes(onglet) ? onglet : '#votre-organisation';
   };
 
@@ -77,7 +77,7 @@
 {#if lienActif === '#votre-organisation'}
   <ResultatsMonOrganisation {animeTuiles} dateRealisation={dateRealisationDernierTest} {defilementAutomatique} />
 {:else if lienActif === '#historique' && $profilStore}
-  <HistoriqueTests {idResultatTest} />
+  <HistoriqueTests {idRésultatTest} />
 {:else if $profilStore}
   <ComparaisonTest />
 {/if}

--- a/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import NavigationTertiaire from '../navigation/NavigationTertiaire.svelte';
+  import type { IdNiveau } from '../niveaux-maturite/NiveauxMaturite.type';
   import { profilStore } from '../stores/profil.store';
   import { fabriqueFilAriane } from '../ui/filAriane';
   import FilAriane, { type Props as PropriétésFilAriane } from '../ui/FilAriane.svelte';
@@ -17,8 +18,9 @@
   type CleOnglet = (typeof clesOnglet)[number];
 
   export let animeTuiles = true;
-  export let dateRealisationDernierTest: Date | undefined = undefined;
+  export let dateRealisation: Date | undefined = undefined;
   export let defilementAutomatique = true;
+  export let idNiveau: IdNiveau;
 
   let lienActif: CleOnglet | undefined;
   let idRésultatTest: string | undefined;
@@ -75,7 +77,7 @@
 <PropositionRefaireTest />
 
 {#if lienActif === '#votre-organisation'}
-  <ResultatsMonOrganisation {animeTuiles} dateRealisation={dateRealisationDernierTest} {defilementAutomatique} />
+  <ResultatsMonOrganisation {animeTuiles} {dateRealisation} {defilementAutomatique} {idNiveau} />
 {:else if lienActif === '#historique' && $profilStore}
   <HistoriqueTests {idRésultatTest} />
 {:else if $profilStore}

--- a/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/ResultatsTestMaturite.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import NavigationTertiaire from '../navigation/NavigationTertiaire.svelte';
+  import { extraisSegmentsDuFragment } from '../navigation/fragmentDeNavigation.svelte';
   import type { IdNiveau } from '../niveaux-maturite/NiveauxMaturite.type';
   import { profilStore } from '../stores/profil.store';
   import { fabriqueFilAriane } from '../ui/filAriane';
@@ -14,7 +15,7 @@
   import Lien from '../ui/Lien.svelte';
   import Alternatives from '../ui/Alternatives.svelte';
 
-  const clesOnglet = ['votre-organisation', 'comparaison', 'historique'];
+  const clesOnglet = ['#votre-organisation', '#comparaison', '#historique'] as const;
   type CleOnglet = (typeof clesOnglet)[number];
 
   export let animeTuiles = true;
@@ -27,10 +28,12 @@
   let propriétésFilAriane: PropriétésFilAriane;
 
   const changeOngletActif = () => {
-    const ongletRiche = window.location.hash.slice(1).split('/');
-    const onglet = ongletRiche[0];
-    idRésultatTest = ongletRiche?.[1];
-    lienActif = clesOnglet.includes(onglet) ? onglet : '#votre-organisation';
+    const [onglet, id] = extraisSegmentsDuFragment(window.location.hash);
+    const fragmentOnglet = `#${onglet}`;
+    idRésultatTest = id;
+    lienActif = clesOnglet.includes(fragmentOnglet as CleOnglet)
+      ? (fragmentOnglet as CleOnglet)
+      : '#votre-organisation';
   };
 
   onMount(() => {

--- a/front/lib-svelte/src/test-maturite/Serie.ts
+++ b/front/lib-svelte/src/test-maturite/Serie.ts
@@ -1,5 +1,5 @@
 import type { IdNiveau } from '../niveaux-maturite/NiveauxMaturite.type';
-import type { ReponsesResultatTest } from './ResultatsTest.type';
+import type { RéponsesResultatTest } from './ResultatsTest.type';
 
 export type ElementSerie = {
   valeur: number;
@@ -9,7 +9,7 @@ export type Serie = ElementSerie[];
 
 export type SerieRadar = {
   id: IdNiveau;
-  valeurs: ReponsesResultatTest;
+  valeurs: RéponsesResultatTest;
   couleur: string;
 };
 

--- a/front/lib-svelte/src/test-maturite/TestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/TestMaturite.svelte
@@ -104,10 +104,14 @@
 
   $: enSessionGroupe = !!codeSessionGroupe;
   $: organisateurSessionGroupe = enSessionGroupe && organisateurSession;
+  $: moyenne =
+    $questionnaireStore.toutesLesReponses.reduce((accumulateur, réponse) => accumulateur + réponse, 0) /
+    $questionnaireStore.toutesLesReponses.length;
+  $: idNiveau = calculeIdNiveau(moyenne);
 </script>
 
 {#if afficheResultats}
-  <ResultatsTestMaturite />
+  <ResultatsTestMaturite {idNiveau} />
 {:else if introFaite}
   <dsfr-container class="test-maturite">
     <div class="lien-retour">

--- a/front/lib-svelte/src/test-maturite/TestMaturite.svelte
+++ b/front/lib-svelte/src/test-maturite/TestMaturite.svelte
@@ -6,6 +6,7 @@
   import Bouton from '../ui/Bouton.svelte';
   import Etapier from '../ui/Etapier.svelte';
   import Lien from '../ui/Lien.svelte';
+  import { calculeIdNiveau } from '../niveaux-maturite/calculeIdNiveau';
   import IntroductionTestMaturite from './IntroductionTestMaturite.svelte';
   import ResultatsTestMaturite from './ResultatsTestMaturite.svelte';
   import { enregistreIdResultatTestPourRevendication } from './resultatTest';

--- a/front/lib-svelte/src/test-maturite/stores/questionnaire.store.ts
+++ b/front/lib-svelte/src/test-maturite/stores/questionnaire.store.ts
@@ -1,5 +1,4 @@
 import { derived, writable } from 'svelte/store';
-import type { RéponsesResultatTest } from '../ResultatsTest.type';
 
 export type Questionnaire = {
   questionCourante: number;
@@ -24,18 +23,6 @@ export const questionnaireStore = {
   reviensEnArriere() {
     update((state) => {
       state.questionCourante--;
-      return state;
-    });
-  },
-
-  chargeRéponses(reponses: RéponsesResultatTest) {
-    update((state) => {
-      state.toutesLesReponses[0] = reponses['prise-en-compte-risque'] - 1;
-      state.toutesLesReponses[1] = reponses.posture - 1;
-      state.toutesLesReponses[2] = reponses.pilotage - 1;
-      state.toutesLesReponses[3] = reponses['ressources-humaines'] - 1;
-      state.toutesLesReponses[4] = reponses.budget - 1;
-      state.toutesLesReponses[5] = reponses['adoption-solutions'] - 1;
       return state;
     });
   },

--- a/front/lib-svelte/src/test-maturite/stores/questionnaire.store.ts
+++ b/front/lib-svelte/src/test-maturite/stores/questionnaire.store.ts
@@ -1,5 +1,5 @@
 import { derived, writable } from 'svelte/store';
-import type { ReponsesResultatTest } from '../ResultatsTest.type';
+import type { RéponsesResultatTest } from '../ResultatsTest.type';
 
 export type Questionnaire = {
   questionCourante: number;
@@ -28,7 +28,7 @@ export const questionnaireStore = {
     });
   },
 
-  chargeReponses(reponses: ReponsesResultatTest) {
+  chargeRéponses(reponses: RéponsesResultatTest) {
     update((state) => {
       state.toutesLesReponses[0] = reponses['prise-en-compte-risque'] - 1;
       state.toutesLesReponses[1] = reponses.posture - 1;

--- a/front/lib-svelte/test/catalogue/fragmentDeNavigation.spec.ts
+++ b/front/lib-svelte/test/catalogue/fragmentDeNavigation.spec.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import { BesoinCyber } from '../../src/catalogue/Catalogue.types';
 import { Langue } from '../../src/catalogue/Guide.types';
-import { creeLeFragmentDeNavigation } from '../../src/navigation/fragmentDeNavigation.svelte';
+import {
+  creeLeFragmentDeNavigation,
+  extraisSegmentsDuFragment,
+} from '../../src/navigation/fragmentDeNavigation.svelte';
 
 describe('Le fragment de navigation', () => {
+  it.each([
+    ['#votre-organisation', ['votre-organisation']],
+    ['#historique/019ff4ff-f632-715e-926d-99777e40d237', ['historique', '019ff4ff-f632-715e-926d-99777e40d237']],
+    [
+      '#historique/019ff4ff-f632-715e-926d-99777e40d237?filtre=actif',
+      ['historique', '019ff4ff-f632-715e-926d-99777e40d237'],
+    ],
+  ])('extrait les segments du fragment %s', (fragment, segments) => {
+    expect(extraisSegmentsDuFragment(fragment)).toEqual(segments);
+  });
+
   it('permet de récupérer la section', () => {
     const fragmentDeNavigation = creeLeFragmentDeNavigation('#section');
 

--- a/front/lib-svelte/test/niveaux-maturite/calculeIdNiveau.spec.ts
+++ b/front/lib-svelte/test/niveaux-maturite/calculeIdNiveau.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { calculeIdNiveau } from '../../src/niveaux-maturite/calculeIdNiveau';
+
+describe('Le calcul du niveau de maturité', () => {
+  it.each([
+    [0, 'insuffisant'],
+    [1, 'emergent'],
+    [2, 'intermediaire'],
+    [3, 'confirme'],
+    [4, 'optimal'],
+  ] as const)('associe la moyenne %s au niveau %s', (moyenne, niveau) => {
+    expect(calculeIdNiveau(moyenne)).toBe(niveau);
+  });
+});


### PR DESCRIPTION
Maintenant, la responsabilité du calcul du niveau est reportée au consommateur de `ResultatsMonOrganisation`

Si un id est détecté dans l'URL, alors le composant `ResultatsTestMaturite` passe en props l'ID au composant `HistoriqueTetss`  qui affiche conditionnement le composant `ResultatsMonOrganisation`
