### PR TITLE
[IA] Ajoute le MCP Serena

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,14 @@
+[mcp_servers.serena]
+command = "uvx"
+args = [
+  "--from",
+  "git+https://github.com/oraios/serena",
+  "serena",
+  "start-mcp-server",
+  "--project-from-cwd",
+  "--context=codex",
+  "--open-web-dashboard",
+  "false",
+]
+startup_timeout_sec = 60
+env = { GEM_HOME = ".gems", UV_CACHE_DIR = ".uv-cache", UV_TOOL_DIR = ".uv-tools", UV_PYTHON_INSTALL_DIR = ".uv-python" }

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ mise-a-jour-financements/rapports
 .nix-bin
 .corepack
 .gems
+.uv-cache
+.uv-tools
+.uv-python
 
 # Playwright-cli
 .playwright-cli

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ mise-a-jour-financements/rapports
 .nix-bin
 .corepack
 .gems
+
+# Playwright-cli
+.playwright-cli

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,23 @@
+{
+  "mcpServers": {
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena",
+        "start-mcp-server",
+        "--project-from-cwd",
+        "--context=claude-code",
+        "--open-web-dashboard",
+        "false"
+      ],
+      "env": {
+        "GEM_HOME": "${CLAUDE_PROJECT_DIR}/.gems",
+        "UV_CACHE_DIR": "${CLAUDE_PROJECT_DIR}/.uv-cache",
+        "UV_TOOL_DIR": "${CLAUDE_PROJECT_DIR}/.uv-tools",
+        "UV_PYTHON_INSTALL_DIR": "${CLAUDE_PROJECT_DIR}/.uv-python"
+      }
+    }
+  }
+}

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,3 @@
+/cache
+/logs
+/project.local.yml

--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone,
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets.
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes.
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,177 @@
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
+project_name: 'anssi-portail'
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: 'utf-8'
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend: 'LSP'
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
+ls_specific_settings: {}
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+  - '.'
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ''
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# list of language servers to start when using the LSP backend; choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some language servers require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple language servers, the first language server that supports a given file will be used for that file.
+# The first language server is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+# list of language servers used by Serena for this local project.
+language_servers:
+  - svelte
+  - html
+  - scss
+  - json
+  - yaml
+  - nix
+  - ruby
+  - bash
+  - toml
+  - markdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file provides guidance to AI coding agents when working with code in this r
 **anssi-portail** is a monorepo containing the ANSSI web portal: a backend API server (Node.js/Express/TypeScript) with PostgreSQL, and a frontend with Jekyll static site generator and Svelte components.
 
 **Tech stack:**
+
 - Backend: Node.js (>=24), TypeScript, Express, PostgreSQL
 - Frontend: Jekyll + Svelte
 - Package manager: pnpm (v10.24.0)
@@ -20,6 +21,10 @@ This file provides guidance to AI coding agents when working with code in this r
 - [mise-a-jour-financements/](mise-a-jour-financements/AGENTS.md) - Data sync utility for financing information
 - [demande-diag/](demande-diag/AGENTS.md) - Web Component for diagnostic questionnaire
 - [comparaison-grist/](comparaison-grist/AGENTS.md) - Utility for comparing content with Grist spreadsheets
+
+## Agent Tooling
+
+For coding tasks, use the Serena MCP server: read its initial instructions first, then prefer semantic tools when useful.
 
 ## Essential Commands
 
@@ -42,6 +47,7 @@ pnpm lint && pnpm format              # Check and fix code style
 ## Configuration
 
 Copy `.env.template` to `.env` and fill in:
+
 - Database credentials (auto-configured for Docker dev setup)
 - Authentication secrets (JWT, OIDC)
 - External service APIs (Brevo email, S3, Sentry)
@@ -57,6 +63,7 @@ Copy `.env.template` to `.env` and fill in:
 ## Docker & Deployment
 
 Multi-stage build creates static site + compiled backend. See `Dockerfile` for:
+
 1. Svelte build
 2. Jekyll build (with build-arg variables for tracking, Sentry)
 3. TypeScript compilation

--- a/default.nix
+++ b/default.nix
@@ -26,8 +26,17 @@ in
     packages = with pkgs; [
       nodejs
       corepack
+      uv
       ruby_4_0
       bundler
+      bash-language-server
+      marksman
+      nixd
+      ruby-lsp
+      svelte-language-server
+      taplo
+      vscode-langservers-extracted
+      yaml-language-server
       docker-compose
       playwrightCli
       prek
@@ -39,9 +48,12 @@ in
       export GEM_HOME="$PWD/.gems"
       export COREPACK_HOME="$PWD/.corepack"
       export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+      export UV_CACHE_DIR="$PWD/.uv-cache"
+      export UV_TOOL_DIR="$PWD/.uv-tools"
+      export UV_PYTHON_INSTALL_DIR="$PWD/.uv-python"
       export PATH="$PWD/.nix-bin:$GEM_HOME/bin:$PATH"
 
-      mkdir -p "$PWD/.nix-bin" "$GEM_HOME" "$COREPACK_HOME"
+      mkdir -p "$PWD/.nix-bin" "$GEM_HOME" "$COREPACK_HOME" "$UV_CACHE_DIR" "$UV_TOOL_DIR" "$UV_PYTHON_INSTALL_DIR"
 
       # Corepack creates the pnpm shim in .nix-bin and installs the version
       # declared in package.json on first shell entry.


### PR DESCRIPTION
[Serena](https://oraios.github.io/serena/01-about/000_intro.html) permet d'utiliser les capacités des [LSP](https://microsoft.github.io/language-server-protocol/) en exposant un [MCP](https://modelcontextprotocol.io/docs/2026-07-28/getting-started/intro) aux agents IA.

Cela permet de faciliter et améliorer l'analyse statique du projet et également de réduire potentiellement la consommation de tokens.

J'ai configuré les LSPs pour les langages utilisés par le projet, à savoir `svelte`, `html`, `scss`, `json`, `yaml`, `nix`, `ruby`, `bash`, `toml`, `markdown`