### PR TITLE
[DEV] Fiabilise l’utilisation du package Axios local

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -2,17 +2,18 @@
 
 Sommaire
 
-1. [installer la toolchain](#1-dépendances-de-développement) ;
-2. [initialiser le fichier de variables d'environnement](#2-initialisation-du-fichier-de-variables-denvironnement) ;
-3. [construire l'application](#3-construire-lapplication) ;
-4. [Initialiser la base de données](#4-initialisation-de-la-base-de-données) ;
-5. [installer les dépendances du projet](#5-installation-des-dépendances-du-projet) ;
-6. [installer Prek](#6-installation-de-prek) ;
-7. [démarrer l'application en local](#7-démarrer-lapplication-en-local) ;
+1. [installer les dépendances de développement](#1-dépendances-de-développement) ;
+1. [installer la toolchain](#2-installation-toolchain) ;
+1. [initialiser le fichier de variables d'environnement](#3-initialisation-du-fichier-de-variables-denvironnement) ;
+1. [installer les dépendances du projet](#4-installation-des-dépendances-du-projet) ;
+1. [Initialiser la base de données](#5-initialisation-de-la-base-de-données) ;
+1. [installer Prek](#6-installation-de-prek) ;
+1. [démarrer l'application en local](#7-démarrage-de-lapplication-en-local) ;
+1. [construire l'application](#8-construire-lapplication)
 
 ## 1. Dépendances de développement
 
-### Prérequis
+Les outils suivants doivent être présent sur le poste :
 
 - `docker` ou n'importe quel runtime OCI compatible avec `docker-compose`
 - `nix` package manager
@@ -20,7 +21,7 @@ Sommaire
   - MacOS: [🍎 documentation NixOS](https://nixos.org/download/#nix-install-macos)
 - `direnv` (_optionnel_): [Documentation officielle](https://direnv.net/docs/installation.html)
 
-### Installation toolchain
+## 2. Installation toolchain
 
 > Pour mettre à jour les dépendances, voir [Mettre à jour la toolchain](docs/developpement/mettre-a-jour-toolchain.md)
 
@@ -44,22 +45,19 @@ direnv allow
 
 Maintenant, vous avez les dépendances de projet **automatiquement chargées** lorsque vous allez sur le projet en question via votre terminal
 
-## 2. Initialisation du fichier de variables d'environnement
+## 3. Initialisation du fichier de variables d'environnement
 
 Créer un fichier de variables d'environnement, en se basant sur le fichier `.env.template`
 
-## 3. Construire l'application
+## 4. Installation des dépendances du projet
 
-Le build de l'application se fait avec la commande `pnpm build`, tant en local que sur la CI/CD.
+Installer les dépendances Jekyll et Node du projet :
 
 ```shell
-pnpm build
+pnpm bootstrap
 ```
 
-> Les variables d'environnement nécessaires au moment du build doivent être disponibles lors de l'exécution de cette commande.
-> Elles sont passées à Jekyll via le plugin [jekyll-dotenv](https://www.rubydoc.info/gems/jekyll-dotenv/0.2.0).
-
-## 4. Initialisation de la base de données
+## 5. Initialisation de la base de données
 
 1. Démarrer le conteneur de base de données :
 
@@ -97,14 +95,6 @@ pnpm admin:dev
 docker compose down db
 ```
 
-## 5. Installation des dépendances du projet
-
-Installer les dépendances Jekyll et Node du projet :
-
-```shell
-pnpm bootstrap
-```
-
 ## 6. Installation de Prek
 
 Installer le hook de pre-commit du dépôt :
@@ -120,3 +110,11 @@ pnpm dev
 ```
 
 À partir d'ici, le site doit être consultable sur http://127.0.0.1:3000
+
+## 8. Construire l'application
+
+Le build de l'application se fait avec la commande `pnpm build`, tant en local que sur la CI/CD.
+
+```shell
+pnpm build
+```

--- a/axios/package.json
+++ b/axios/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
+      "anssi-portail:source": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/back/AGENTS.md
+++ b/back/AGENTS.md
@@ -26,7 +26,7 @@ pnpm --filter @anssi-portail/back dev:server    # Just the server (not DB)
 
 # Testing
 pnpm --filter @anssi-portail/back test          # Run all tests
-node --import tsx --test tests/path/to/file.spec.ts  # Single file
+node --conditions=anssi-portail:source --import tsx --test tests/path/to/file.spec.ts  # Single file
 
 # Quality
 pnpm --filter @anssi-portail/back lint          # ESLint
@@ -74,7 +74,7 @@ pnpm --filter @anssi-portail/back build         # Compile to dist/
 
 ## Admin Console
 
-Access with `pnpm admin` (production) or `pnpm admin:dev` (auto-build).
+Access with `pnpm admin` (production build) or `pnpm admin:dev` (TypeScript sources through `tsx`).
 
 **Common operations:**
 

--- a/back/AGENTS.md
+++ b/back/AGENTS.md
@@ -74,7 +74,7 @@ pnpm --filter @anssi-portail/back build         # Compile to dist/
 
 ## Admin Console
 
-Access with `pnpm admin` (production build) or `pnpm admin:dev` (TypeScript sources through `tsx`).
+Access with `pnpm admin` (builds production artifacts) or `pnpm admin:dev` (TypeScript sources through `tsx`).
 
 **Common operations:**
 

--- a/back/package.json
+++ b/back/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "dev": "npm-run-all --parallel --race dev:bdd dev:server",
     "dev:bdd": "docker compose up db",
-    "dev:server": "sleep 3 && pnpm migre-bdd && node --import tsx --env-file ../.env --watch src/serveur.ts",
+    "dev:server": "sleep 3 && pnpm migre-bdd && node --conditions=anssi-portail:source --import tsx --env-file ../.env --watch src/serveur.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -17,8 +17,8 @@
     "prelint": "[ -d ../regles-eslint/dist ] || pnpm -F regles-eslint build",
     "prestart": "tsc && pnpm migre-bdd:clever",
     "pretest": "npm-run-all --parallel typecheck lint",
-    "test": "node --import tsx --test './tests/**/*.spec.ts'",
-    "test:ci": "node --import tsx --test './tests/**/*.spec.ts'",
+    "test": "node --conditions=anssi-portail:source --import tsx --test './tests/**/*.spec.ts'",
+    "test:ci": "node --conditions=anssi-portail:source --import tsx --test './tests/**/*.spec.ts'",
     "typecheck": "tsc --noEmit"
   },
   "engines": {

--- a/comparaison-grist/package.json
+++ b/comparaison-grist/package.json
@@ -9,8 +9,8 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "dev:guides:compare": "node --import tsx --env-file .env src/guides.ts",
-    "start:guides:compare": "node --import tsx src/guides.ts",
+    "dev:guides:compare": "node --conditions=anssi-portail:source --import tsx --env-file .env src/guides.ts",
+    "start:guides:compare": "node --conditions=anssi-portail:source --import tsx src/guides.ts",
     "lint:fix": "eslint . --fix",
     "lint": "eslint .",
     "test": "pnpm typecheck && vitest run",

--- a/mise-a-jour-financements/package.json
+++ b/mise-a-jour-financements/package.json
@@ -5,13 +5,13 @@
   "main": "src/index.ts",
   "type": "module",
   "scripts": {
-    "start": "node --import tsx src/index.ts",
-    "dev": "node --env-file ../.env --env-file .env --import tsx src/index.ts",
+    "start": "node --conditions=anssi-portail:source --import tsx src/index.ts",
+    "dev": "node --conditions=anssi-portail:source --env-file ../.env --env-file .env --import tsx src/index.ts",
     "lint:fix": "eslint . --fix",
     "lint": "eslint .",
     "pretest": "npm-run-all --parallel typecheck lint",
-    "test:ci": "node --import tsx --test './tests/**/*.spec.ts'",
-    "test": "node --import tsx --test './tests/**/*.spec.ts'",
+    "test:ci": "node --conditions=anssi-portail:source --import tsx --test './tests/**/*.spec.ts'",
+    "test": "node --conditions=anssi-portail:source --import tsx --test './tests/**/*.spec.ts'",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "serveur.ts",
   "packageManager": "pnpm@10.24.0",
   "scripts": {
+    "preadmin": "pnpm --filter @anssi-portail/axios build && pnpm --filter @anssi-portail/back build",
     "admin": "node -e \"const admin = new (require('./back/dist/src/admin/consoleAdministration.js').ConsoleAdministration)()\" -i",
     "admin:dev": "node --conditions=anssi-portail:source --import tsx --env-file .env -e \"const admin = new (require('./back/src/admin/consoleAdministration.ts').ConsoleAdministration)()\" -i",
     "bootstrap": "(bundler check --gemfile=front/Gemfile || bundler install --gemfile=front/Gemfile) && pnpm install --frozen-lockfile",
@@ -17,7 +18,7 @@
     "preinstall": "npx only-allow@1.2.2 pnpm",
     "postinstall": "pnpm -F regles-eslint build",
     "start": "node back/dist/src/serveur.js",
-    "prestart": "pnpm --filter @anssi-portail/back prestart"
+    "prestart": "pnpm --filter @anssi-portail/axios build && pnpm --filter @anssi-portail/back prestart"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "packageManager": "pnpm@10.24.0",
   "scripts": {
     "admin": "node -e \"const admin = new (require('./back/dist/src/admin/consoleAdministration.js').ConsoleAdministration)()\" -i",
-    "admin:dev": "pnpm -F @anssi-portail/back build && node --env-file .env -e \"const admin = new (require('./back/dist/src/admin/consoleAdministration.js').ConsoleAdministration)()\" -i",
+    "admin:dev": "node --conditions=anssi-portail:source --import tsx --env-file .env -e \"const admin = new (require('./back/src/admin/consoleAdministration.ts').ConsoleAdministration)()\" -i",
     "bootstrap": "(bundler check --gemfile=front/Gemfile || bundler install --gemfile=front/Gemfile) && pnpm install --frozen-lockfile",
     "build": "pnpm --reporter=append-only -r build",
-    "dev": "concurrently -n \"SERVEUR,SVELTE,JEKYLL,BDD,MIGRE\" --prefix-colors \"cyan,green,magenta,blue,yellow\" \"SVELTE_DEV_LOCAL_AVEC_HOT_RELOAD=true node --watch --import tsx --env-file .env ./back/src/serveur.ts\" \"pnpm --filter @anssi-portail/svelte watch\" \"sleep 5 && SVELTE_DEV_LOCAL_AVEC_HOT_RELOAD=true ${GEM_HOME}/bin/jekyll build -s ./front -d ./front/_site -w\" \"docker compose up db\" \"sleep 3 && pnpm migre-bdd\"",
+    "dev": "concurrently -n \"SERVEUR,SVELTE,JEKYLL,BDD,MIGRE\" --prefix-colors \"cyan,green,magenta,blue,yellow\" \"SVELTE_DEV_LOCAL_AVEC_HOT_RELOAD=true node --conditions=anssi-portail:source --watch --import tsx --env-file .env ./back/src/serveur.ts\" \"pnpm --filter @anssi-portail/svelte watch\" \"sleep 5 && SVELTE_DEV_LOCAL_AVEC_HOT_RELOAD=true ${GEM_HOME}/bin/jekyll build -s ./front -d ./front/_site -w\" \"docker compose up db\" \"sleep 3 && pnpm migre-bdd\"",
     "lint": "pnpm -r lint",
     "format": "pnpm --reporter=append-only -r format",
     "test": "pnpm --reporter=append-only -r test",


### PR DESCRIPTION
Le package workspace `@anssi-portail/axios` expose son code exécutable depuis `dist`. Les commandes utilisant `tsx` nécessitaient donc une compilation préalable du package, notamment pour `pnpm dev`, `pnpm admin:dev` et certains tests isolés.