### PR TITLE
[CORRECTION] Ajuste l'image du bandeau de l'ancienne DA

### DIFF
--- a/front/lib-svelte/src/catalogue/guides/Guide.svelte
+++ b/front/lib-svelte/src/catalogue/guides/Guide.svelte
@@ -95,6 +95,7 @@
     theme="clair"
     ficheCatalogue
     illustrationSource={guide.illustration.grande}
+    cacheActions={guide.documents.length !== 1}
   >
     {#snippet filAriane()}
       <FilAriane {...propriétésFilAriane} />
@@ -220,16 +221,14 @@
     flex-direction: column-reverse;
 
     img {
-      display: none;
+      display: block;
       width: 588px;
       object-fit: cover;
       object-position: top;
       height: 330px;
       background-color: var(--background-default-grey);
-
-      @include a-partir-de(xxl) {
-        display: block;
-      }
+      max-width: 100%;
+      margin-inline: auto;
     }
   }
 

--- a/front/lib-svelte/src/ui/Heros.svelte
+++ b/front/lib-svelte/src/ui/Heros.svelte
@@ -159,7 +159,7 @@
         </div>
       {/if}
       {#if !cacheIllustration}
-        <picture slot="seo">
+        <picture slot="media">
           {#if illustration}
             {@render illustration({
               source: illustrationSource,
@@ -231,7 +231,11 @@
         grid-area: illustration;
 
         &.ficheCatalogue {
-          align-self: flex-end;
+          display: none;
+          @include a-partir-de(lg) {
+            display: grid;
+            align-self: flex-end;
+          }
         }
 
         img {
@@ -239,7 +243,7 @@
           align-self: center;
           justify-self: center;
 
-          @include a-partir-de(md) {
+          @include a-partir-de(lg) {
             max-width: none;
           }
         }
@@ -272,10 +276,6 @@
     .contenu-section {
       .actions {
         margin: 0;
-      }
-
-      // 768px et plus
-      @include a-partir-de(md) {
       }
 
       // 1248px et plus
@@ -359,7 +359,7 @@
         min-height: 2.5rem;
       }
 
-      @include a-partir-de(md) {
+      @include a-partir-de(lg) {
         .actions {
           margin-bottom: 4.5rem;
         }


### PR DESCRIPTION
|Actuel|Corrigé|
|-|-|
|<img width="1146" height="890" alt="image" src="https://github.com/user-attachments/assets/7d128855-c6b7-4c6e-ba95-56cf7f74295b" />|<img width="1144" height="880" alt="image" src="https://github.com/user-attachments/assets/070b9c15-ddf0-435b-bf90-77d14298bd1d" />|